### PR TITLE
add ci releases and brew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.x
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,0 +1,64 @@
+project_name: miactl
+before:
+  hooks:
+    - go mod download
+    - go generate ./...
+release:
+  prerelease: false
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - 386
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - 7
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X github.com/mia-platform/miactl/cmd.version={{.Version}} -X github.com/mia-platform/miactl/cmd.commit={{.Commit}} -X github.com/mia-platform/miactl/cmd.date={{.Date}}
+signs:
+  - artifacts: none
+
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      bit: Arm
+      bitv6: Arm6
+      bitv7: Arm7
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+# Homebrews
+brews:
+  - name: miactl
+    github:
+      owner: mia-platform
+      name: homebrew-tap
+    commit_author:
+      name: thobianchi
+      email: thomas.bianchi8@gmail.com
+    folder: Formula
+    homepage: https://mia-platform.eu
+    description: miactl is the cli of the mia-platform DevOps Console
+    test: |
+      system "miactl help"


### PR DESCRIPTION
This implements #4 
I'm using my account to do the commit in the homebrew-tap repo. If this works we should consider create a bot account.

After merge make a tag and magic should happen