### PR TITLE
refactor: moved structures to a specific file

### DIFF
--- a/sdk/project_repository.go
+++ b/sdk/project_repository.go
@@ -1,0 +1,32 @@
+package sdk
+
+// Cluster object, different for environment
+type Cluster struct {
+	Hostname  string `json:"hostname"`
+	Namespace string `json:"namespace"`
+}
+
+// Environment of the project
+type Environment struct {
+	DisplayName string  `json:"label"`
+	EnvID       string  `json:"value"`
+	Cluster     Cluster `json:"cluster"`
+}
+
+// Pipelines type supported by project
+type Pipelines struct {
+	Type string `json:"type"`
+}
+
+// Project define the mia-platform console project
+type Project struct {
+	ID                   string        `json:"_id"`
+	Name                 string        `json:"name"`
+	ConfigurationGitPath string        `json:"configurationGitPath"`
+	Environments         []Environment `json:"environments"`
+	ProjectID            string        `json:"projectId"`
+	Pipelines            Pipelines     `json:"pipelines"`
+}
+
+// Projects is a list of project
+type Projects []Project

--- a/sdk/projects.go
+++ b/sdk/projects.go
@@ -8,50 +8,19 @@ import (
 	"github.com/davidebianchi/go-jsonclient"
 )
 
-// Cluster object, different for environment
-type Cluster struct {
-	Hostname  string `json:"hostname"`
-	Namespace string `json:"namespace"`
-}
-
-// Environment of the project
-type Environment struct {
-	DisplayName string  `json:"label"`
-	EnvID       string  `json:"value"`
-	Cluster     Cluster `json:"cluster"`
-}
-
-// Pipelines type supported by project
-type Pipelines struct {
-	Type string `json:"type"`
-}
-
-// Project define the mia-platform console project
-type Project struct {
-	ID                   string        `json:"_id"`
-	Name                 string        `json:"name"`
-	ConfigurationGitPath string        `json:"configurationGitPath"`
-	Environments         []Environment `json:"environments"`
-	ProjectID            string        `json:"projectId"`
-	Pipelines            Pipelines     `json:"pipelines"`
-}
-
-// Projects is a list of project
-type Projects []Project
-
-// ProjectsClient is the console implementations of the IProjects interface
+// ProjectsClient is the console implementations of the IProjects interface.
 type ProjectsClient struct {
 	JSONClient *jsonclient.Client
 }
 
-// Get method to fetch the console projects
+// Get method to fetch the console projects.
 func (p ProjectsClient) Get() (Projects, error) {
 	req, err := p.JSONClient.NewRequest(http.MethodGet, "api/backend/projects/", nil)
 	if err != nil {
 		return nil, err
 	}
 
-	projects := Projects{}
+	var projects Projects
 	var httpErr *jsonclient.HTTPError
 	_, err = p.JSONClient.Do(req, &projects)
 	if err != nil {


### PR DESCRIPTION
I'm suggesting this change to promote a different sdk structure separating structures from client interfaces.

For instance I wanted to implement deploy history retrieval and thus I need to implement a specific structure to serialize information and I wanted to extend the Project struct to feature new functions (such as GetDeployHistory). 