### PR TITLE
Deploy api migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-  - get history of deployments a project environment
+  - get history of deployments for a specific project environment
   - add get projects command
   - create cli sdk
   - create cli renderer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+  - get history of deployments a project environment
   - add get projects command
   - create cli sdk
   - create cli renderer

--- a/sdk/deploy.go
+++ b/sdk/deploy.go
@@ -50,7 +50,7 @@ func (d DeployClient) GetHistory(query DeployHistoryQuery) ([]DeployItem, error)
 		return nil, err
 	}
 
-	path := fmt.Sprintf("api/backend/projects/%s/deployment/?page=1&per_page=25&sort=desc", project.ID)
+	path := fmt.Sprintf("api/deploy/projects/%s/deployment/?page=1&per_page=25&sort=desc", project.ID)
 
 	historyReq, err := d.JSONClient.NewRequest(http.MethodGet, path, nil)
 	if err != nil {

--- a/sdk/deploy_test.go
+++ b/sdk/deploy_test.go
@@ -27,6 +27,7 @@ func TestDeployGetHistory(t *testing.T) {
 	historyRequestAssertions := func(t *testing.T, req *http.Request) {
 		t.Helper()
 
+		require.Equal(t, "/api/deploy/projects/mongo-id-2/deployment/", req.URL.Path)
 		require.Equal(t, http.MethodGet, req.Method)
 		cookieSid, err := req.Cookie("sid")
 		require.NoError(t, err)


### PR DESCRIPTION
Deployment API will soon be migrated from `/api/backend` to `/api/deploy`, this PR will come handy when the migration goes in production