### PR TITLE
Feature: new deploy status command to monitor the status

### DIFF
--- a/cmd/console/deploy/deploy.go
+++ b/cmd/console/deploy/deploy.go
@@ -70,6 +70,9 @@ func NewDeployCmd() *cobra.Command {
 	cmd.MarkFlagRequired("environment")
 	cmd.MarkFlagRequired("revision")
 
+	// subcommands
+	cmd.AddCommand(NewStatusCmd())
+
 	return cmd
 }
 

--- a/cmd/console/deploy/status.go
+++ b/cmd/console/deploy/status.go
@@ -1,0 +1,117 @@
+package deploy
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/davidebianchi/go-jsonclient"
+	"github.com/mia-platform/miactl/sdk"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type statusResponse struct {
+	PipelineId int    `json:"id"`
+	Status     string `json:"status"`
+}
+
+func NewStatusCmd() *cobra.Command {
+	var (
+		baseURL  string
+		apiToken string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "verify status of deploy pipeline",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			baseURL = viper.GetString("apibaseurl")
+			apiToken = viper.GetString("apitoken")
+
+			if apiToken == "" {
+				return errors.New("missing API token - please login")
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if baseURL == "" {
+				return errors.New("API base URL not specified nor configured")
+			}
+
+			var pipelines sdk.PipelinesConfig
+			if err := viper.UnmarshalKey(triggeredPipelinesKey, &pipelines); err != nil {
+				return err
+			}
+
+			lastEndedDeploy, err := statusMonitor(cmd.OutOrStdout(), baseURL, apiToken, &pipelines)
+			if err != nil {
+				return err
+			}
+
+			viper.Set(triggeredPipelinesKey, pipelines[lastEndedDeploy+1:])
+			if err := viper.WriteConfig(); err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "all deploy pipelines triggered have completed")
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func statusMonitor(w io.Writer, baseURL, apiToken string, pipelines *sdk.PipelinesConfig) (int, error) {
+	lastEndedDeploy := -1
+	JSONClient, err := jsonclient.New(jsonclient.Options{
+		BaseURL: baseURL,
+		Headers: jsonclient.Headers{
+			"Authorization": fmt.Sprintf("Bearer %s", apiToken),
+		},
+	})
+	if err != nil {
+		return lastEndedDeploy, fmt.Errorf("error creating JSON client: %w", err)
+	}
+
+	for i, p := range *pipelines {
+		statusEndpoint := fmt.Sprintf("/api/deploy/projects/%s/pipelines/%d/status/?environment=%s", p.ProjectId, p.PipelineId, p.Environment)
+
+		var response statusResponse
+		response, err = getStatus(JSONClient, statusEndpoint)
+		if err != nil {
+			return i, err
+		}
+		for response.Status != "success" && response.Status != "failed" {
+			time.Sleep(2 * time.Second)
+			response, err = getStatus(JSONClient, statusEndpoint)
+			if err != nil {
+				return i, err
+			}
+		}
+		fmt.Fprintf(w, "project: %s\tpipeline: %d\tstatus:%s\n", p.ProjectId, p.PipelineId, response.Status)
+		lastEndedDeploy = i
+	}
+
+	return lastEndedDeploy, nil
+}
+
+func getStatus(jc *jsonclient.Client, endpoint string) (statusResponse, error) {
+	req, err := jc.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return statusResponse{}, fmt.Errorf("error creating status request: %w", err)
+	}
+
+	var statusRes statusResponse
+
+	rawRes, err := jc.Do(req, &statusRes)
+	if err != nil {
+		return statusResponse{}, fmt.Errorf("status error: %w", err)
+	}
+	defer rawRes.Body.Close()
+
+	return statusRes, nil
+}

--- a/cmd/console/deploy/status.go
+++ b/cmd/console/deploy/status.go
@@ -57,15 +57,22 @@ func NewStatusCmd() *cobra.Command {
 				return nil
 			}
 
-			statusResponse, err := f.MiaClient.Deploy.GetDeployStatus(projectId, pipelineId, environment)
+			result, err := f.MiaClient.Deploy.GetDeployStatus(projectId, pipelineId, environment)
 			if err != nil {
 				f.Renderer.Error(err).Render()
 				return nil
 			}
 
-			visualizeStatusResponse(f, projectId, statusResponse)
+			visualizeStatusResponse(f, projectId, result)
 
-			return nil
+			switch result.Status {
+			case sdk.Failed:
+				return fmt.Errorf("Deploy pipeline failed")
+			case sdk.Canceled:
+				return fmt.Errorf("Deploy pipeline canceled")
+			default:
+				return nil
+			}
 		},
 	}
 

--- a/cmd/console/deploy/status.go
+++ b/cmd/console/deploy/status.go
@@ -3,11 +3,9 @@ package deploy
 import (
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"time"
 
-	"github.com/davidebianchi/go-jsonclient"
+	"github.com/mia-platform/miactl/factory"
 	"github.com/mia-platform/miactl/sdk"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -15,34 +13,6 @@ import (
 
 const checkDelay = 2 * time.Second
 const endMessage = "all deploy pipelines triggered have completed"
-
-const (
-	Created  PipelineStatus = "created"
-	Pending                 = "pending"
-	Running                 = "running"
-	Success                 = "success"
-	Failed                  = "failed"
-	Canceled                = "canceled"
-)
-
-type PipelineStatus string
-
-type statusResponse struct {
-	PipelineId int    `json:"id"`
-	Status     string `json:"status"`
-}
-
-type sleeper interface {
-	Sleep()
-}
-
-type timeSleeper struct {
-	delay time.Duration
-}
-
-func (ts *timeSleeper) Sleep() {
-	time.Sleep(ts.delay)
-}
 
 func NewStatusCmd() *cobra.Command {
 	var (
@@ -57,6 +27,9 @@ func NewStatusCmd() *cobra.Command {
 			baseURL = viper.GetString("apibaseurl")
 			apiToken = viper.GetString("apitoken")
 
+			if baseURL == "" {
+				return errors.New("API base URL not specified nor configured")
+			}
 			if apiToken == "" {
 				return errors.New("missing API token - please login")
 			}
@@ -64,12 +37,16 @@ func NewStatusCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if baseURL == "" {
-				return errors.New("API base URL not specified nor configured")
+			f, err := factory.FromContext(cmd.Context(), sdk.Options{
+				APIBaseURL: baseURL,
+				APIToken:   apiToken,
+			})
+			if err != nil {
+				return err
 			}
 
 			var pipelines sdk.PipelinesConfig
-			if err := viper.UnmarshalKey(triggeredPipelinesKey, &pipelines); err != nil {
+			if err := readPipelines(&pipelines); err != nil {
 				return err
 			}
 
@@ -78,85 +55,20 @@ func NewStatusCmd() *cobra.Command {
 				return nil
 			}
 
-			tSleep := &timeSleeper{checkDelay}
-			lastEndedDeploy, err := statusMonitor(cmd.OutOrStdout(), baseURL, apiToken, &pipelines, tSleep)
+			tSleep := &sdk.TimeSleeper{Delay: checkDelay}
+			lastEndedDeploy, err := f.MiaClient.Deploy.StatusMonitor(cmd.OutOrStdout(), &pipelines, tSleep)
 			if err != nil {
 				return err
 			}
 
-			viper.Set(triggeredPipelinesKey, pipelines[lastEndedDeploy:])
-			if err := viper.WriteConfig(); err != nil {
+			if err := storePipelines(pipelines[lastEndedDeploy:]); err != nil {
 				return err
 			}
 
-			fmt.Fprintln(cmd.OutOrStdout(), "all deploy pipelines triggered have completed")
+			fmt.Fprintln(cmd.OutOrStdout(), endMessage)
 			return nil
 		},
 	}
 
 	return cmd
-}
-
-func statusMonitor(w io.Writer, baseURL, apiToken string, pipelines *sdk.PipelinesConfig, sl sleeper) (int, error) {
-	lastEndedDeploy := 0
-	JSONClient, err := jsonclient.New(jsonclient.Options{
-		BaseURL: baseURL,
-		Headers: jsonclient.Headers{
-			"Authorization": fmt.Sprintf("Bearer %s", apiToken),
-		},
-	})
-	if err != nil {
-		return lastEndedDeploy, fmt.Errorf("error creating JSON client: %w", err)
-	}
-
-	for _, p := range *pipelines {
-		statusEndpoint := fmt.Sprintf("/api/deploy/projects/%s/pipelines/%d/status/?environment=%s", p.ProjectId, p.PipelineId, p.Environment)
-
-		var response statusResponse
-		response, err = getStatus(JSONClient, statusEndpoint)
-		if err != nil {
-			return lastEndedDeploy, err
-		}
-		for shouldRetry(response) {
-			sl.Sleep()
-			response, err = getStatus(JSONClient, statusEndpoint)
-			if err != nil {
-				return lastEndedDeploy, err
-			}
-		}
-		fmt.Fprintf(w, "project: %s\tpipeline: %d\tstatus:%s\n", p.ProjectId, p.PipelineId, response.Status)
-		lastEndedDeploy += 1
-	}
-
-	return lastEndedDeploy, nil
-}
-
-func getStatus(jc *jsonclient.Client, endpoint string) (statusResponse, error) {
-	req, err := jc.NewRequest(http.MethodGet, endpoint, nil)
-	if err != nil {
-		return statusResponse{}, fmt.Errorf("error creating status request: %w", err)
-	}
-
-	var statusRes statusResponse
-
-	rawRes, err := jc.Do(req, &statusRes)
-	if err != nil {
-		return statusResponse{}, fmt.Errorf("status error: %w", err)
-	}
-	defer rawRes.Body.Close()
-
-	return statusRes, nil
-}
-
-func shouldRetry(sr statusResponse) bool {
-	switch sr.Status {
-	case Success:
-		return false
-	case Failed:
-		return false
-	case Canceled:
-		return false
-	default:
-		return true
-	}
 }

--- a/cmd/console/deploy/status.go
+++ b/cmd/console/deploy/status.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mia-platform/miactl/factory"
 	"github.com/mia-platform/miactl/sdk"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/console/deploy/status_test.go
+++ b/cmd/console/deploy/status_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mia-platform/miactl/factory"
 	"github.com/mia-platform/miactl/renderer"
 	"github.com/mia-platform/miactl/sdk"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"

--- a/cmd/console/deploy/status_test.go
+++ b/cmd/console/deploy/status_test.go
@@ -65,10 +65,11 @@ func TestNewStatusCmd(t *testing.T) {
 		err := cmd.ExecuteContext(context.Background())
 		require.NoError(t, err)
 
-		outputLines := strings.Split(buf.String(), "\n")
+		rawOutputLines := strings.Split(buf.String(), "\n")
+		outputLines := sliceFilter(t, rawOutputLines)
 
 		// account for one more line that inform that all deploy were completed
-		require.Equal(t, len(pipelinesTriggered), len(sliceFilter(t, outputLines))-1)
+		require.Equal(t, len(pipelinesTriggered), len(outputLines)-1)
 		for idx, pipeline := range pipelinesTriggered {
 			require.Equal(
 				t,
@@ -76,6 +77,7 @@ func TestNewStatusCmd(t *testing.T) {
 				outputLines[idx],
 			)
 		}
+		require.Equal(t, endMessage, outputLines[len(sliceFilter(t, outputLines))-1])
 
 		var pipelines sdk.PipelinesConfig
 		require.NoError(t, viper.UnmarshalKey(triggeredPipelinesKey, &pipelines))
@@ -84,7 +86,74 @@ func TestNewStatusCmd(t *testing.T) {
 		require.True(t, gock.IsDone())
 	})
 
-	t.Run("get status - failed to obtain ", func(t *testing.T) {
+	t.Run("get status with success after pending", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+		defer gock.Off()
+
+		const expectedStatus = Success
+		pipelinesTriggered := sdk.PipelinesConfig{
+			sdk.PipelineConfig{
+				ProjectId:   projectId,
+				PipelineId:  pipelineId,
+				Environment: environment,
+			},
+		}
+
+		pipelineStatuses := []PipelineStatus{Pending, expectedStatus}
+
+		for _, ps := range pipelineStatuses {
+			gock.New(baseURL).
+				Get(statusEndpoint).
+				MatchParam("environment", environment).
+				Reply(200).
+				JSON(map[string]interface{}{
+					"id":     pipelineId,
+					"status": ps,
+				})
+		}
+
+		viper.SetConfigFile("/tmp/.miaplatformctl.yaml")
+
+		viper.Set("apibaseurl", baseURL)
+		viper.Set("apitoken", apiToken)
+		viper.Set("project", projectId)
+		viper.Set(triggeredPipelinesKey, pipelinesTriggered)
+		viper.WriteConfigAs("/tmp/.miaplatformctl.yaml")
+
+		buf := &bytes.Buffer{}
+		cmd := NewStatusCmd()
+		// needed since the test command does not inherit root command settings
+		cmd.SilenceUsage = true
+
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+
+		err := cmd.ExecuteContext(context.Background())
+		require.NoError(t, err)
+
+		rawOutputLines := strings.Split(buf.String(), "\n")
+		outputLines := sliceFilter(t, rawOutputLines)
+
+		// account for one more line that inform that all deploy were completed
+		require.Equal(t, len(pipelinesTriggered), len(outputLines)-1)
+		for idx, pipeline := range pipelinesTriggered {
+			require.Equal(
+				t,
+				fmt.Sprintf("project: %s\tpipeline: %d\tstatus:%s", pipeline.ProjectId, pipeline.PipelineId, expectedStatus),
+				outputLines[idx],
+			)
+		}
+		require.Equal(t, endMessage, outputLines[len(sliceFilter(t, outputLines))-1])
+
+		var pipelines sdk.PipelinesConfig
+		require.NoError(t, viper.UnmarshalKey(triggeredPipelinesKey, &pipelines))
+		require.Empty(t, pipelines)
+
+		require.True(t, gock.IsDone())
+	})
+
+	t.Run("get status - failed to obtain it", func(t *testing.T) {
 		viper.Reset()
 		defer viper.Reset()
 		defer gock.Off()
@@ -134,6 +203,109 @@ func TestNewStatusCmd(t *testing.T) {
 
 		require.True(t, gock.IsDone())
 	})
+
+	t.Run("get status - missing API token", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+		defer gock.Off()
+
+		pipelinesTriggered := sdk.PipelinesConfig{
+			sdk.PipelineConfig{
+				ProjectId:   projectId,
+				PipelineId:  pipelineId,
+				Environment: environment,
+			},
+		}
+
+		viper.SetConfigFile("/tmp/.miaplatformctl.yaml")
+
+		viper.Set("apibaseurl", baseURL)
+		viper.Set("project", projectId)
+		viper.Set(triggeredPipelinesKey, pipelinesTriggered)
+		viper.WriteConfigAs("/tmp/.miaplatformctl.yaml")
+
+		buf := &bytes.Buffer{}
+		cmd := NewStatusCmd()
+		// needed since the test command does not inherit root command settings
+		cmd.SilenceUsage = true
+
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+
+		err := cmd.ExecuteContext(context.Background())
+		require.EqualError(t, err, "missing API token - please login")
+
+		var pipelines sdk.PipelinesConfig
+		require.NoError(t, viper.UnmarshalKey(triggeredPipelinesKey, &pipelines))
+		require.Equal(t, 1, len(pipelines))
+		require.Equal(t, pipelinesTriggered, pipelines)
+	})
+
+	t.Run("get status - missing base url", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+		defer gock.Off()
+
+		pipelinesTriggered := sdk.PipelinesConfig{
+			sdk.PipelineConfig{
+				ProjectId:   projectId,
+				PipelineId:  pipelineId,
+				Environment: environment,
+			},
+		}
+
+		viper.SetConfigFile("/tmp/.miaplatformctl.yaml")
+
+		viper.Set("apitoken", apiToken)
+		viper.Set("project", projectId)
+		viper.Set(triggeredPipelinesKey, pipelinesTriggered)
+		viper.WriteConfigAs("/tmp/.miaplatformctl.yaml")
+
+		buf := &bytes.Buffer{}
+		cmd := NewStatusCmd()
+		// needed since the test command does not inherit root command settings
+		cmd.SilenceUsage = true
+
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+
+		err := cmd.ExecuteContext(context.Background())
+		require.EqualError(t, err, "API base URL not specified nor configured")
+
+		var pipelines sdk.PipelinesConfig
+		require.NoError(t, viper.UnmarshalKey(triggeredPipelinesKey, &pipelines))
+		require.Equal(t, 1, len(pipelines))
+		require.Equal(t, pipelinesTriggered, pipelines)
+	})
+
+	t.Run("get status - no pipeline previously triggered", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+		defer gock.Off()
+
+		viper.SetConfigFile("/tmp/.miaplatformctl.yaml")
+
+		viper.Set("apibaseurl", baseURL)
+		viper.Set("apitoken", apiToken)
+		viper.Set("project", projectId)
+		viper.WriteConfigAs("/tmp/.miaplatformctl.yaml")
+
+		buf := &bytes.Buffer{}
+		cmd := NewStatusCmd()
+		// needed since the test command does not inherit root command settings
+		cmd.SilenceUsage = true
+
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+
+		require.NoError(t, cmd.ExecuteContext(context.Background()))
+
+		require.Equal(t, "no deploy pipelines triggered found\n", buf.String())
+
+		var pipelines sdk.PipelinesConfig
+		require.NoError(t, viper.UnmarshalKey(triggeredPipelinesKey, &pipelines))
+		require.Equal(t, 0, len(pipelines))
+	})
 }
 
 func TestStatusMonitor(t *testing.T) {
@@ -144,18 +316,54 @@ func TestStatusMonitor(t *testing.T) {
 		apiToken    = "YWNjZXNzVG9rZW4="
 		environment = "preprod"
 	)
-	statusEndpoint := fmt.Sprintf("/api/deploy/projects/%s/pipelines/%d/status/", projectId, pipelineId)
 
 	t.Run("get status - success immediately", func(t *testing.T) {
-		const expectedStatus = "success"
-		gock.New(baseURL).
-			Get(statusEndpoint).
-			MatchParam("environment", environment).
-			Reply(200).
-			JSON(map[string]interface{}{
-				"id":     pipelineId,
-				"status": expectedStatus,
-			})
+		defer gock.Off()
+
+		const expectedStatus = Success
+		pipelinesTriggered := sdk.PipelinesConfig{
+			sdk.PipelineConfig{
+				ProjectId:   projectId,
+				PipelineId:  pipelineId,
+				Environment: environment,
+			},
+			sdk.PipelineConfig{
+				ProjectId:   "dc24c12fe",
+				PipelineId:  143295,
+				Environment: environment,
+			},
+		}
+
+		for _, p := range pipelinesTriggered {
+			statusEndpoint := fmt.Sprintf("/api/deploy/projects/%s/pipelines/%d/status/", p.ProjectId, p.PipelineId)
+			gock.New(baseURL).
+				Get(statusEndpoint).
+				MatchParam("environment", p.Environment).
+				Reply(200).
+				JSON(map[string]interface{}{
+					"id":     pipelineId,
+					"status": expectedStatus,
+				})
+		}
+
+		buf := &bytes.Buffer{}
+		slm := &sleeperMock{}
+
+		lastDeployedCompleted, err := statusMonitor(buf, baseURL, apiToken, &pipelinesTriggered, slm)
+
+		require.NoError(t, err)
+		require.Equal(t, len(pipelinesTriggered), lastDeployedCompleted, "all the deploy were completed")
+		require.Empty(t, slm.CallCount, "no need to wait")
+
+		require.True(t, gock.IsDone())
+	})
+
+	t.Run("get status - pending -> running -> success", func(t *testing.T) {
+		defer gock.Off()
+
+		const finalStatus = Success
+		const runningTimes = 2
+		statusEndpoint := fmt.Sprintf("/api/deploy/projects/%s/pipelines/%d/status/", projectId, pipelineId)
 
 		pipelinesTriggered := sdk.PipelinesConfig{
 			sdk.PipelineConfig{
@@ -165,21 +373,72 @@ func TestStatusMonitor(t *testing.T) {
 			},
 		}
 
+		pipelineStatuses := []PipelineStatus{Created, Pending, Running, Running, finalStatus}
+
+		for _, ps := range pipelineStatuses {
+			gock.New(baseURL).
+				Get(statusEndpoint).
+				MatchParam("environment", environment).
+				Reply(200).
+				JSON(map[string]interface{}{
+					"id":     pipelineId,
+					"status": ps,
+				})
+		}
+
 		buf := &bytes.Buffer{}
 		slm := &sleeperMock{}
 
 		lastDeployedCompleted, err := statusMonitor(buf, baseURL, apiToken, &pipelinesTriggered, slm)
 
 		require.NoError(t, err)
-		require.Equal(t, len(pipelinesTriggered)-1, lastDeployedCompleted, "all the deploy were completed")
-		require.Empty(t, slm.CallCount, "no need to wait")
+		require.Equal(t, len(pipelinesTriggered), lastDeployedCompleted, "all the deploy were completed")
+		require.Equal(t, len(pipelineStatuses)-1, slm.CallCount, "wait when created, pending and running received")
 
 		require.True(t, gock.IsDone())
 	})
 
-	t.Run("get status - pending -> running -> success", func(t *testing.T) {
-		const finalStatus = Success
-		const runningTimes = 2
+	t.Run("get status - running -> failed", func(t *testing.T) {
+		defer gock.Off()
+		const finalStatus = Failed
+		statusEndpoint := fmt.Sprintf("/api/deploy/projects/%s/pipelines/%d/status/", projectId, pipelineId)
+
+		pipelinesTriggered := sdk.PipelinesConfig{
+			sdk.PipelineConfig{
+				ProjectId:   projectId,
+				PipelineId:  pipelineId,
+				Environment: environment,
+			},
+		}
+
+		pipelineStatuses := []PipelineStatus{Running, finalStatus}
+
+		for _, ps := range pipelineStatuses {
+			gock.New(baseURL).
+				Get(statusEndpoint).
+				MatchParam("environment", environment).
+				Reply(200).
+				JSON(map[string]interface{}{
+					"id":     pipelineId,
+					"status": ps,
+				})
+		}
+
+		buf := &bytes.Buffer{}
+		slm := &sleeperMock{}
+
+		lastDeployedCompleted, err := statusMonitor(buf, baseURL, apiToken, &pipelinesTriggered, slm)
+
+		require.NoError(t, err)
+		require.Equal(t, len(pipelinesTriggered), lastDeployedCompleted, "all the deploy were completed")
+		require.Equal(t, 1, slm.CallCount, "wait once when running received")
+
+		require.True(t, gock.IsDone())
+	})
+
+	t.Run("get status - error", func(t *testing.T) {
+		defer gock.Off()
+		statusEndpoint := fmt.Sprintf("/api/deploy/projects/%s/pipelines/%d/status/", projectId, pipelineId)
 
 		gock.New(baseURL).
 			Get(statusEndpoint).
@@ -193,30 +452,8 @@ func TestStatusMonitor(t *testing.T) {
 		gock.New(baseURL).
 			Get(statusEndpoint).
 			MatchParam("environment", environment).
-			Reply(200).
-			JSON(map[string]interface{}{
-				"id":     pipelineId,
-				"status": Pending,
-			})
-
-		gock.New(baseURL).
-			Get(statusEndpoint).
-			Times(runningTimes).
-			MatchParam("environment", environment).
-			Reply(200).
-			JSON(map[string]interface{}{
-				"id":     pipelineId,
-				"status": Running,
-			})
-
-		gock.New(baseURL).
-			Get(statusEndpoint).
-			MatchParam("environment", environment).
-			Reply(200).
-			JSON(map[string]interface{}{
-				"id":     pipelineId,
-				"status": finalStatus,
-			})
+			Reply(400).
+			JSON(map[string]interface{}{})
 
 		pipelinesTriggered := sdk.PipelinesConfig{
 			sdk.PipelineConfig{
@@ -231,9 +468,10 @@ func TestStatusMonitor(t *testing.T) {
 
 		lastDeployedCompleted, err := statusMonitor(buf, baseURL, apiToken, &pipelinesTriggered, slm)
 
-		require.NoError(t, err)
-		require.Equal(t, len(pipelinesTriggered)-1, lastDeployedCompleted, "all the deploy were completed")
-		require.Equal(t, 4, slm.CallCount, "wait when created, pending and running received")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "status error:")
+		require.Empty(t, lastDeployedCompleted, "no deploy was completed")
+		require.Equal(t, 1, slm.CallCount, "wait only once")
 
 		require.True(t, gock.IsDone())
 	})

--- a/cmd/console/deploy/status_test.go
+++ b/cmd/console/deploy/status_test.go
@@ -1,0 +1,97 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/mia-platform/miactl/sdk"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestNewStatusCmd(t *testing.T) {
+	const (
+		projectId   = "4h6UBlNiZOk2"
+		pipelineId  = 564745
+		baseURL     = "http://console-base-url/"
+		apiToken    = "YWNjZXNzVG9rZW4="
+		environment = "test"
+	)
+	statusEndpoint := fmt.Sprintf("/api/deploy/projects/%s/pipelines/%d/status/", projectId, pipelineId)
+
+	t.Run("get status with success", func(t *testing.T) {
+		viper.Reset()
+		defer viper.Reset()
+		defer gock.Off()
+
+		const expectedStatus = "success"
+		pipelinesTriggered := sdk.PipelinesConfig{
+			sdk.PipelineConfig{
+				ProjectId:   projectId,
+				PipelineId:  pipelineId,
+				Environment: environment,
+			},
+		}
+
+		gock.New(baseURL).
+			Get(statusEndpoint).
+			MatchParam("environment", environment).
+			Reply(200).
+			JSON(map[string]interface{}{
+				"id":     pipelineId,
+				"status": expectedStatus,
+			})
+
+		viper.SetConfigFile("/tmp/.miaplatformctl.yaml")
+
+		viper.Set("apibaseurl", baseURL)
+		viper.Set("apitoken", apiToken)
+		viper.Set("project", projectId)
+		viper.Set(triggeredPipelinesKey, pipelinesTriggered)
+		viper.WriteConfigAs("/tmp/.miaplatformctl.yaml")
+
+		buf := &bytes.Buffer{}
+		cmd := NewStatusCmd()
+
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+
+		err := cmd.ExecuteContext(context.Background())
+		require.NoError(t, err)
+
+		outputLines := strings.Split(buf.String(), "\n")
+
+		// account for one more line that inform that all deploy were completed
+		require.Equal(t, len(pipelinesTriggered), len(sliceFilter(t, outputLines))-1)
+		for idx, pipeline := range pipelinesTriggered {
+			require.Equal(
+				t,
+				fmt.Sprintf("project: %s\tpipeline: %d\tstatus:%s", pipeline.ProjectId, pipeline.PipelineId, expectedStatus),
+				outputLines[idx],
+			)
+		}
+
+		var pipelines sdk.PipelinesConfig
+		require.NoError(t, viper.UnmarshalKey(triggeredPipelinesKey, &pipelines))
+		require.Equal(t, 0, len(pipelines))
+
+		require.True(t, gock.IsDone())
+	})
+}
+
+func sliceFilter(t testing.TB, s []string) []string {
+	t.Helper()
+	filtered := []string{}
+
+	for _, e := range s {
+		if e != "" {
+			filtered = append(filtered, e)
+		}
+	}
+
+	return filtered
+}

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -3,7 +3,6 @@ package sdk
 import (
 	"errors"
 	"fmt"
-	"io"
 
 	"github.com/davidebianchi/go-jsonclient"
 )
@@ -30,7 +29,7 @@ type DeployHistoryQuery struct {
 type IDeploy interface {
 	GetHistory(DeployHistoryQuery) ([]DeployItem, error)
 	Trigger(string, DeployConfig) (DeployResponse, error)
-	StatusMonitor(w io.Writer, pipelines *PipelinesConfig, sl Sleeper) (int, error)
+	GetDeployStatus(string, int, string) (StatusResponse, error)
 }
 
 // MiaClient is the client of the sdk to be used to communicate with Mia

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/davidebianchi/go-jsonclient"
 )
@@ -29,6 +30,7 @@ type DeployHistoryQuery struct {
 type IDeploy interface {
 	GetHistory(DeployHistoryQuery) ([]DeployItem, error)
 	Trigger(string, DeployConfig) (DeployResponse, error)
+	StatusMonitor(w io.Writer, pipelines *PipelinesConfig, sl Sleeper) (int, error)
 }
 
 // MiaClient is the client of the sdk to be used to communicate with Mia

--- a/sdk/deploy.go
+++ b/sdk/deploy.go
@@ -149,11 +149,9 @@ func (d DeployClient) Trigger(projectId string, cfg DeployConfig) (DeployRespons
 
 // GetDeployStatus interacts with Mia Platform APIs to retrieve selected pipeline status
 func (d DeployClient) GetDeployStatus(projectId string, pipelineId int, environment string) (StatusResponse, error) {
-	var statusEndpoint string
+	statusEndpoint := fmt.Sprintf("/api/deploy/projects/%s/pipelines/%d/status/", projectId, pipelineId)
 	if environment != "" {
-		statusEndpoint = fmt.Sprintf("/api/deploy/projects/%s/pipelines/%d/status/?environment=%s", projectId, pipelineId, environment)
-	} else {
-		statusEndpoint = fmt.Sprintf("/api/deploy/projects/%s/pipelines/%d/status/", projectId, pipelineId)
+		statusEndpoint = fmt.Sprintf("%s?environment=%s", statusEndpoint, environment)
 	}
 
 	req, err := d.JSONClient.NewRequest(http.MethodGet, statusEndpoint, nil)

--- a/sdk/deploy.go
+++ b/sdk/deploy.go
@@ -111,7 +111,9 @@ func (d DeployClient) Trigger(projectId string, cfg DeployConfig) (DeployRespons
 		data.ForceDeployWhenNoSemver = true
 	}
 
-	request, err := d.JSONClient.NewRequest(http.MethodPost, getDeployEndpoint(projectId), data)
+	path := fmt.Sprintf("api/deploy/projects/%s/trigger/pipeline/", projectId)
+
+	request, err := d.JSONClient.NewRequest(http.MethodPost, path, data)
 	if err != nil {
 		return DeployResponse{}, fmt.Errorf("error creating deploy request: %w", err)
 	}
@@ -124,8 +126,4 @@ func (d DeployClient) Trigger(projectId string, cfg DeployConfig) (DeployRespons
 	rawRes.Body.Close()
 
 	return response, nil
-}
-
-func getDeployEndpoint(projectId string) string {
-	return fmt.Sprintf("api/deploy/projects/%s/trigger/pipeline/", projectId)
 }

--- a/sdk/deploy_test.go
+++ b/sdk/deploy_test.go
@@ -14,10 +14,6 @@ import (
 	"gopkg.in/h2non/gock.v1"
 )
 
-type sleeperMock struct {
-	CallCount int
-}
-
 func TestDeployGetHistory(t *testing.T) {
 	projectsListResponseBody := readTestData(t, "projects.json")
 	projectRequestAssertions := func(t *testing.T, req *http.Request) {

--- a/sdk/deploy_test.go
+++ b/sdk/deploy_test.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net/http"
@@ -13,6 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 )
+
+type sleeperMock struct {
+	CallCount int
+}
 
 func TestDeployGetHistory(t *testing.T) {
 	projectsListResponseBody := readTestData(t, "projects.json")
@@ -290,6 +295,176 @@ func TestTrigger(t *testing.T) {
 		require.True(t, gock.IsDone())
 	})
 }
+func TestStatusMonitor(t *testing.T) {
+	const (
+		projectId   = "u543t8sdf34t5"
+		pipelineId  = 32562
+		baseURL     = "http://console-base-url/"
+		apiToken    = "YWNjZXNzVG9rZW4="
+		environment = "preprod"
+	)
+
+	client := testCreateDeployClientToken(t, baseURL, apiToken)
+
+	t.Run("get status - success immediately", func(t *testing.T) {
+		defer gock.Off()
+
+		const expectedStatus = Success
+		pipelinesTriggered := PipelinesConfig{
+			PipelineConfig{
+				ProjectId:   projectId,
+				PipelineId:  pipelineId,
+				Environment: environment,
+			},
+			PipelineConfig{
+				ProjectId:   "dc24c12fe",
+				PipelineId:  143295,
+				Environment: environment,
+			},
+		}
+
+		for _, p := range pipelinesTriggered {
+			statusEndpoint := fmt.Sprintf("/api/deploy/projects/%s/pipelines/%d/status/", p.ProjectId, p.PipelineId)
+			gock.New(baseURL).
+				Get(statusEndpoint).
+				MatchParam("environment", p.Environment).
+				Reply(200).
+				JSON(map[string]interface{}{
+					"id":     pipelineId,
+					"status": expectedStatus,
+				})
+		}
+
+		buf := &bytes.Buffer{}
+		slm := &sleeperMock{}
+
+		lastDeployedCompleted, err := client.StatusMonitor(buf, &pipelinesTriggered, slm)
+
+		require.NoError(t, err)
+		require.Equal(t, len(pipelinesTriggered), lastDeployedCompleted, "all the deploy were completed")
+		require.Empty(t, slm.CallCount, "no need to wait")
+
+		require.True(t, gock.IsDone())
+	})
+
+	t.Run("get status - pending -> running -> success", func(t *testing.T) {
+		defer gock.Off()
+
+		const finalStatus = Success
+		const runningTimes = 2
+		statusEndpoint := fmt.Sprintf("/api/deploy/projects/%s/pipelines/%d/status/", projectId, pipelineId)
+
+		pipelinesTriggered := PipelinesConfig{
+			PipelineConfig{
+				ProjectId:   projectId,
+				PipelineId:  pipelineId,
+				Environment: environment,
+			},
+		}
+
+		pipelineStatuses := []PipelineStatus{Created, Pending, Running, Running, finalStatus}
+
+		for _, ps := range pipelineStatuses {
+			gock.New(baseURL).
+				Get(statusEndpoint).
+				MatchParam("environment", environment).
+				Reply(200).
+				JSON(map[string]interface{}{
+					"id":     pipelineId,
+					"status": ps,
+				})
+		}
+
+		buf := &bytes.Buffer{}
+		slm := &sleeperMock{}
+
+		lastDeployedCompleted, err := client.StatusMonitor(buf, &pipelinesTriggered, slm)
+
+		require.NoError(t, err)
+		require.Equal(t, len(pipelinesTriggered), lastDeployedCompleted, "all the deploy were completed")
+		require.Equal(t, len(pipelineStatuses)-1, slm.CallCount, "wait when created, pending and running received")
+
+		require.True(t, gock.IsDone())
+	})
+
+	t.Run("get status - running -> failed", func(t *testing.T) {
+		defer gock.Off()
+		const finalStatus = Failed
+		statusEndpoint := fmt.Sprintf("/api/deploy/projects/%s/pipelines/%d/status/", projectId, pipelineId)
+
+		pipelinesTriggered := PipelinesConfig{
+			PipelineConfig{
+				ProjectId:   projectId,
+				PipelineId:  pipelineId,
+				Environment: environment,
+			},
+		}
+
+		pipelineStatuses := []PipelineStatus{Running, finalStatus}
+
+		for _, ps := range pipelineStatuses {
+			gock.New(baseURL).
+				Get(statusEndpoint).
+				MatchParam("environment", environment).
+				Reply(200).
+				JSON(map[string]interface{}{
+					"id":     pipelineId,
+					"status": ps,
+				})
+		}
+
+		buf := &bytes.Buffer{}
+		slm := &sleeperMock{}
+
+		lastDeployedCompleted, err := client.StatusMonitor(buf, &pipelinesTriggered, slm)
+
+		require.NoError(t, err)
+		require.Equal(t, len(pipelinesTriggered), lastDeployedCompleted, "all the deploy were completed")
+		require.Equal(t, 1, slm.CallCount, "wait once when running received")
+
+		require.True(t, gock.IsDone())
+	})
+
+	t.Run("get status - error", func(t *testing.T) {
+		defer gock.Off()
+		statusEndpoint := fmt.Sprintf("/api/deploy/projects/%s/pipelines/%d/status/", projectId, pipelineId)
+
+		gock.New(baseURL).
+			Get(statusEndpoint).
+			MatchParam("environment", environment).
+			Reply(200).
+			JSON(map[string]interface{}{
+				"id":     pipelineId,
+				"status": Created,
+			})
+
+		gock.New(baseURL).
+			Get(statusEndpoint).
+			MatchParam("environment", environment).
+			Reply(400).
+			JSON(map[string]interface{}{})
+
+		pipelinesTriggered := PipelinesConfig{
+			PipelineConfig{
+				ProjectId:   projectId,
+				PipelineId:  pipelineId,
+				Environment: environment,
+			},
+		}
+
+		buf := &bytes.Buffer{}
+		slm := &sleeperMock{}
+
+		lastDeployedCompleted, err := client.StatusMonitor(buf, &pipelinesTriggered, slm)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "status error:")
+		require.Empty(t, lastDeployedCompleted, "no deploy was completed")
+		require.Equal(t, 1, slm.CallCount, "wait only once")
+
+		require.True(t, gock.IsDone())
+	})
+}
 
 func testCreateDeployClientCookie(t *testing.T, url string) IDeploy {
 	t.Helper()
@@ -321,4 +496,8 @@ func testCreateDeployClientToken(t *testing.T, url, apiToken string) IDeploy {
 	return DeployClient{
 		JSONClient: client,
 	}
+}
+
+func (sm *sleeperMock) Sleep() {
+	sm.CallCount += 1
 }

--- a/sdk/testing.go
+++ b/sdk/testing.go
@@ -1,5 +1,7 @@
 package sdk
 
+import "io"
+
 // ProjectsMock is useful to be used to mock projects client
 type ProjectsMock struct {
 	Error    error
@@ -112,4 +114,9 @@ func (d DeployMock) GetHistory(query DeployHistoryQuery) ([]DeployItem, error) {
 // Trigger method mock. Added just to satisfy the interface
 func (d DeployMock) Trigger(projectId string, cfg DeployConfig) (DeployResponse, error) {
 	return DeployResponse{}, nil
+}
+
+// StatusMonitor method mock. Added just to satisfy the interface
+func (d DeployMock) StatusMonitor(w io.Writer, pipelines *PipelinesConfig, sl Sleeper) (int, error) {
+	return 0, nil
 }

--- a/sdk/testing.go
+++ b/sdk/testing.go
@@ -1,7 +1,5 @@
 package sdk
 
-import "io"
-
 // ProjectsMock is useful to be used to mock projects client
 type ProjectsMock struct {
 	Error    error
@@ -117,6 +115,6 @@ func (d DeployMock) Trigger(projectId string, cfg DeployConfig) (DeployResponse,
 }
 
 // StatusMonitor method mock. Added just to satisfy the interface
-func (d DeployMock) StatusMonitor(w io.Writer, pipelines *PipelinesConfig, sl Sleeper) (int, error) {
-	return 0, nil
+func (d DeployMock) GetDeployStatus(projectId string, pipelineId int, environment string) (StatusResponse, error) {
+	return StatusResponse{}, nil
 }


### PR DESCRIPTION
**Note:** This Pull Request should be reviewed only after #40 is closed, since it builds on top of it.

### Proposal

Add a new command that acts on the console resource. This command should check the deploy status of all the pipelines that have been previously triggered using the `deploy` command of `miactl`.

Note: this command does not allow to select a pipeline of a specific project.

```shell
miactl console deploy status
```

### Checklist

- [x] your branch will not cause merge conflict with `master`
- [x] run `go test`
- [x] tests are included
- [ ] the documentation is updated or integrated accordingly with your changes
- [x] the code will follow the lint rules (`goimports`)
- [x] you are not committing extraneous files or sensible data