### PR TITLE
Feat: save login tokens in files

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -31,8 +31,11 @@ import (
 	"github.com/spf13/viper"
 )
 
-const cfgDir = ".config/miactl"
-const cfgFileName = "config"
+const (
+	cfgDir         = ".config/miactl"
+	cfgFileName    = "config"
+	credentialsDir = "credentials"
+)
 
 var (
 	cfgFile   string
@@ -105,6 +108,14 @@ func initConfig() {
 		}
 		if err := viper.SafeWriteConfigAs(path.Join(cfgPath, cfgFileName)); err != nil && verbose {
 			fmt.Println(err)
+		}
+
+		credPath := path.Join(cfgPath, credentialsDir)
+
+		// create a default config file if it does not exist
+		if err := os.MkdirAll(credPath, os.ModePerm); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
 		}
 	}
 

--- a/internal/httphandler/auth.go
+++ b/internal/httphandler/auth.go
@@ -18,8 +18,10 @@ package httphandler
 import (
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/mia-platform/miactl/internal/cmd/login"
+	"github.com/mitchellh/go-homedir"
 )
 
 const credentialsPath = ".config/miactl/credentials"
@@ -35,7 +37,12 @@ type Auth struct {
 }
 
 func (a *Auth) Authenticate() (string, error) {
-	tokens, err := getTokensFromFile(a.url)
+	home, err := homedir.Dir()
+	if err != nil {
+		return "", err
+	}
+	credentialsAbsPath := path.Join(home, credentialsPath)
+	tokens, err := getTokensFromFile(a.url, credentialsAbsPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return "", err
@@ -45,7 +52,7 @@ func (a *Auth) Authenticate() (string, error) {
 				return "", fmt.Errorf("login error: %w", err)
 			}
 
-			err = writeTokensToFile(a.url, tokens)
+			err = writeTokensToFile(a.url, credentialsAbsPath, tokens)
 			if err != nil {
 				return "", err
 			}

--- a/internal/httphandler/credentials.go
+++ b/internal/httphandler/credentials.go
@@ -1,0 +1,85 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httphandler
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/mia-platform/miactl/internal/cmd/login"
+	"github.com/mitchellh/go-homedir"
+)
+
+func getTokensFromFile(url string) (*login.Tokens, error) {
+	sha := getURLSha(url)
+
+	home, err := homedir.Dir()
+	if err != nil {
+		return nil, err
+	}
+
+	credentialsAbsPath := path.Join(home, credentialsPath, sha)
+
+	tokenBytes, err := os.ReadFile(credentialsAbsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var tokens login.Tokens
+	err = json.Unmarshal(tokenBytes, &tokens)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tokens, nil
+}
+
+func writeTokensToFile(url string, tokens *login.Tokens) error {
+	sha := getURLSha(url)
+
+	home, err := homedir.Dir()
+	if err != nil {
+		return err
+	}
+
+	credentialsAbsPath := path.Join(home, credentialsPath, sha)
+	tokenJSON, err := json.Marshal(tokens)
+	if err != nil {
+		return err
+	}
+	credentials := []byte(tokenJSON)
+
+	_, err = os.Stat(credentialsAbsPath)
+	if os.IsNotExist(err) {
+		_, err := os.Create(credentialsAbsPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = os.WriteFile(credentialsAbsPath, credentials, os.ModePerm)
+	return err
+}
+
+func getURLSha(url string) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(url))
+	bs := hasher.Sum(nil)
+	return fmt.Sprintf("%x", bs)
+}

--- a/internal/httphandler/credentials.go
+++ b/internal/httphandler/credentials.go
@@ -23,20 +23,14 @@ import (
 	"path"
 
 	"github.com/mia-platform/miactl/internal/cmd/login"
-	"github.com/mitchellh/go-homedir"
 )
 
-func getTokensFromFile(url string) (*login.Tokens, error) {
+func getTokensFromFile(url, credentialsPath string) (*login.Tokens, error) {
 	sha := getURLSha(url)
 
-	home, err := homedir.Dir()
-	if err != nil {
-		return nil, err
-	}
+	filePath := path.Join(credentialsPath, sha)
 
-	credentialsAbsPath := path.Join(home, credentialsPath, sha)
-
-	tokenBytes, err := os.ReadFile(credentialsAbsPath)
+	tokenBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
@@ -50,30 +44,25 @@ func getTokensFromFile(url string) (*login.Tokens, error) {
 	return &tokens, nil
 }
 
-func writeTokensToFile(url string, tokens *login.Tokens) error {
+func writeTokensToFile(url, credentialsPath string, tokens *login.Tokens) error {
 	sha := getURLSha(url)
 
-	home, err := homedir.Dir()
-	if err != nil {
-		return err
-	}
-
-	credentialsAbsPath := path.Join(home, credentialsPath, sha)
+	filePath := path.Join(credentialsPath, sha)
 	tokenJSON, err := json.Marshal(tokens)
 	if err != nil {
 		return err
 	}
 	credentials := []byte(tokenJSON)
 
-	_, err = os.Stat(credentialsAbsPath)
+	_, err = os.Stat(filePath)
 	if os.IsNotExist(err) {
-		_, err := os.Create(credentialsAbsPath)
+		_, err := os.Create(filePath)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = os.WriteFile(credentialsAbsPath, credentials, os.ModePerm)
+	err = os.WriteFile(filePath, credentials, os.ModePerm)
 	return err
 }
 

--- a/internal/httphandler/credentials.go
+++ b/internal/httphandler/credentials.go
@@ -54,14 +54,6 @@ func writeTokensToFile(url, credentialsPath string, tokens *login.Tokens) error 
 	}
 	credentials := []byte(tokenJSON)
 
-	_, err = os.Stat(filePath)
-	if os.IsNotExist(err) {
-		_, err := os.Create(filePath)
-		if err != nil {
-			return err
-		}
-	}
-
 	err = os.WriteFile(filePath, credentials, os.ModePerm)
 	return err
 }

--- a/internal/httphandler/credentials_test.go
+++ b/internal/httphandler/credentials_test.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	testURLSha  = "b64868a6476817bde1123f534334c2ce78891fcad65c06667acbfdb9007b5dff"
-	testTokens  = `{"accessToken":"test_token"}`
+	testTokens  = `{"accessToken":"test_token","refreshToken":"","expiresAt":0}`
 	invalidJSON = `invalid_json`
 )
 
@@ -68,5 +68,19 @@ func TestGetTokensFromFile(t *testing.T) {
 }
 
 func TestWriteTokensToFile(t *testing.T) {
+	testDirPath = t.TempDir()
+	testFilePath := path.Join(testDirPath, testURLSha)
 
+	var tokens = &login.Tokens{
+		AccessToken: "test_token",
+	}
+
+	err := writeTokensToFile(testBaseURL, testDirPath, tokens)
+	require.NoError(t, err)
+	require.FileExists(t, testFilePath)
+	fileContent, err := os.ReadFile(testFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, testTokens, string(fileContent))
 }

--- a/internal/httphandler/credentials_test.go
+++ b/internal/httphandler/credentials_test.go
@@ -1,0 +1,72 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httphandler
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/mia-platform/miactl/internal/cmd/login"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testURLSha  = "b64868a6476817bde1123f534334c2ce78891fcad65c06667acbfdb9007b5dff"
+	testTokens  = `{"accessToken":"test_token"}`
+	invalidJSON = `invalid_json`
+)
+
+var (
+	testDirPath string
+)
+
+func TestGetURLSha(t *testing.T) {
+	sha := getURLSha(testBaseURL)
+	require.Equal(t, testURLSha, sha)
+}
+
+func TestGetTokensFromFile(t *testing.T) {
+	testDirPath = t.TempDir()
+	testFilePath := path.Join(testDirPath, testURLSha)
+
+	// valid JSON
+	err := os.WriteFile(testFilePath, []byte(testTokens), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokens, err := getTokensFromFile(testBaseURL, testDirPath)
+	require.NoError(t, err)
+	var expectedTokens login.Tokens
+	err = json.Unmarshal([]byte(testTokens), &expectedTokens)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, expectedTokens, *tokens)
+
+	// invalid JSON
+	err = os.WriteFile(testFilePath, []byte(invalidJSON), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = getTokensFromFile(testBaseURL, testDirPath)
+	require.ErrorContains(t, err, "invalid character")
+}
+
+func TestWriteTokensToFile(t *testing.T) {
+
+}


### PR DESCRIPTION
This PR adds support for saving login tokens in files, to avoid logging in at each API request.
The JSON tokens are saved in separate files, named with the SHA256 of the endpoint.