### PR TITLE
Feat/runtime cronjob list command

### DIFF
--- a/docs/30_commands.md
+++ b/docs/30_commands.md
@@ -208,3 +208,23 @@ Available flags for the command:
 - `--context`, to specify a different context from the currently selected one
 - `--company-id`, to set the ID of the desired company
 - `--project-id`, to set the ID of the desired project
+
+### cronjob list
+
+The `runtime cronjob list` subcommand allows you to see all cronjobs that are running for the environment associated
+to a given project.
+
+Usage:
+
+```sh
+miactl runtime cronjob list ENVIRONMENT [flags]
+```
+
+Available flags for the command:
+
+- `--endpoint`, to set the Console endpoint (default is `https://console.cloud.mia-platform.eu`)
+- `--certificate-authority`, to provide the path to a custom CA certificate
+- `--insecure-skip-tls-verify`, to disallow the check the validity of the certificate of the remote endpoint
+- `--context`, to specify a different context from the currently selected one
+- `--company-id`, to set the ID of the desired company
+- `--project-id`, to set the ID of the desired project

--- a/internal/cmd/cronjobs/pods/cronjobs.go
+++ b/internal/cmd/cronjobs/pods/cronjobs.go
@@ -1,0 +1,131 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cronjobs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/mia-platform/miactl/internal/client"
+	"github.com/mia-platform/miactl/internal/clioptions"
+	"github.com/mia-platform/miactl/internal/resources"
+	"github.com/mia-platform/miactl/internal/util"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+const (
+	listEndpointTemplate = "/api/projects/%s/environments/%s/cronjobs/describe/"
+)
+
+func CronjobCmd(o *clioptions.CLIOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cronjob",
+		Short: "Manage Mia-Platform Console project runtime cronjob resources",
+		Long: `Manage Mia-Platform Console project runtime cronjob resources.
+
+A project on Mia-Platform Console once deployed can have one or more cronjob resources associcated with one or more
+of its environments.
+`,
+	}
+
+	// add sub commands
+	cmd.AddCommand(
+		listCmd(o),
+	)
+
+	return cmd
+}
+
+func listCmd(o *clioptions.CLIOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list ENVIRONMENT",
+		Short: "List all cronjobs for a project in an environment",
+		Long:  "List all cronjobs for a project in an environment.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			restConfig, err := o.ToRESTConfig()
+			cobra.CheckErr(err)
+			client, err := client.APIClientForConfig(restConfig)
+			cobra.CheckErr(err)
+			return printCronJobsList(client, restConfig.ProjectID, args[0])
+		},
+	}
+
+	return cmd
+}
+
+func printCronJobsList(client *client.APIClient, projectID, environment string) error {
+	if projectID == "" {
+		return fmt.Errorf("missing project id, please set one with the flag or context")
+	}
+	resp, err := client.
+		Get().
+		APIPath(fmt.Sprintf(listEndpointTemplate, projectID, environment)).
+		Do(context.Background())
+
+	if err != nil {
+		return err
+	}
+
+	if err := resp.Error(); err != nil {
+		return err
+	}
+
+	cronjobs := make([]resources.CronJob, 0)
+	err = resp.ParseResponse(&cronjobs)
+	if err != nil {
+		return err
+	}
+
+	if len(cronjobs) == 0 {
+		fmt.Printf("No cronjobs found for %s environment\n", environment)
+		return nil
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetBorders(tablewriter.Border{Left: false, Top: false, Right: false, Bottom: false})
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeader([]string{"Name", "Schedule", "Suspend", "Active", "Last Schedule", "Age"})
+
+	if err != nil {
+		return err
+	}
+
+	for _, cronjob := range cronjobs {
+		table.Append(rowForCronJob(cronjob))
+	}
+
+	table.Render()
+	return nil
+}
+
+func rowForCronJob(cronjob resources.CronJob) []string {
+	return []string{
+		cronjob.Name,
+		cronjob.Schedule,
+		strconv.FormatBool(cronjob.Suspend),
+		fmt.Sprint(cronjob.Active),
+		util.HumanDuration(time.Since(cronjob.LastSchedule)),
+		util.HumanDuration(time.Since(cronjob.Age)),
+	}
+}

--- a/internal/cmd/cronjobs/pods/cronjobs_test.go
+++ b/internal/cmd/cronjobs/pods/cronjobs_test.go
@@ -1,0 +1,125 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cronjobs
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mia-platform/miactl/internal/client"
+	"github.com/mia-platform/miactl/internal/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintCronJobsList(t *testing.T) {
+	testCases := map[string]struct {
+		testServer *httptest.Server
+		projectID  string
+		err        bool
+	}{
+		"list cronjob with success": {
+			testServer: testServer(t),
+			projectID:  "found",
+		},
+		"list cronjob with empty response": {
+			testServer: testServer(t),
+			projectID:  "empty",
+		},
+		"failed request": {
+			testServer: testServer(t),
+			projectID:  "fail",
+			err:        true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			server := testCase.testServer
+			defer server.Close()
+
+			client, err := client.APIClientForConfig(&client.Config{
+				Host: server.URL,
+			})
+			require.NoError(t, err)
+
+			err = printCronJobsList(client, testCase.projectID, "env-id")
+			if testCase.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRowForCronJob(t *testing.T) {
+	testCases := map[string]struct {
+		cronjob     resources.CronJob
+		expectedRow []string
+	}{
+		"basic cronjob": {
+			cronjob: resources.CronJob{
+				Name:         "cronjob-name",
+				Suspend:      true,
+				Active:       0,
+				Schedule:     "* * * * *",
+				Age:          time.Now().Add(-time.Hour * 24),
+				LastSchedule: time.Now(),
+			},
+			expectedRow: []string{"cronjob-name", "* * * * *", "true", "0", "0s", "24h"},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, testCase.expectedRow, rowForCronJob(testCase.cronjob))
+		})
+	}
+}
+
+func testServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf(listEndpointTemplate, "found", "env-id"):
+			cronjob := resources.CronJob{
+				Name:         "cronjob-name",
+				Suspend:      true,
+				Active:       0,
+				Schedule:     "* * * * *",
+				Age:          time.Now().Add(time.Hour * 24),
+				LastSchedule: time.Now(),
+			}
+			data, err := resources.EncodeResourceToJSON([]resources.CronJob{cronjob})
+			require.NoError(t, err)
+			w.WriteHeader(http.StatusOK)
+			w.Write(data)
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf(listEndpointTemplate, "fail", "env-id"):
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf(listEndpointTemplate, "empty", "env-id"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			assert.Failf(t, "unexpected http call", "received call with method: %s uri %s", r.Method, r.RequestURI)
+		}
+	}))
+	return server
+}

--- a/internal/cmd/cronjobs/pods/doc.go
+++ b/internal/cmd/cronjobs/pods/doc.go
@@ -1,0 +1,17 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// cronjobs package contains subcommands and functions for managing cronjobs
+package cronjobs

--- a/internal/cmd/pods/pods.go
+++ b/internal/cmd/pods/pods.go
@@ -158,6 +158,6 @@ func rowForPod(pod resources.Pod) []string {
 		fmt.Sprintf("%d/%d", readyContainers, totalContainers),
 		caser.String(pod.Phase),
 		fmt.Sprint(totalRestart),
-		util.HumanDuration(time.Since(pod.StartTime)),
+		util.HumanDuration(time.Since(pod.Age)),
 	}
 }

--- a/internal/cmd/pods/pods_test.go
+++ b/internal/cmd/pods/pods_test.go
@@ -76,10 +76,10 @@ func TestRowForPod(t *testing.T) {
 	}{
 		"basic pod": {
 			pod: resources.Pod{
-				Name:      "pod-name",
-				Phase:     "running",
-				Status:    "ok",
-				StartTime: time.Now(),
+				Name:   "pod-name",
+				Phase:  "running",
+				Status: "ok",
+				Age:    time.Now(),
 				Component: []struct {
 					Name    string `json:"name"`
 					Version string `json:"version"`
@@ -104,13 +104,13 @@ func TestRowForPod(t *testing.T) {
 		},
 		"pod without component": {
 			pod: resources.Pod{
-				StartTime: time.Now(),
+				Age: time.Now(),
 			},
 			expectedRow: []string{"", "", "-", "0/0", "", "0", "0s"},
 		},
 		"pod without component version": {
 			pod: resources.Pod{
-				StartTime: time.Now(),
+				Age: time.Now(),
 				Component: []struct {
 					Name    string `json:"name"`
 					Version string `json:"version"`
@@ -122,7 +122,7 @@ func TestRowForPod(t *testing.T) {
 		},
 		"pod without component name": {
 			pod: resources.Pod{
-				StartTime: time.Now(),
+				Age: time.Now(),
 				Component: []struct {
 					Name    string `json:"name"`
 					Version string `json:"version"`
@@ -134,7 +134,7 @@ func TestRowForPod(t *testing.T) {
 		},
 		"pod without multiple components": {
 			pod: resources.Pod{
-				StartTime: time.Now(),
+				Age: time.Now(),
 				Component: []struct {
 					Name    string `json:"name"`
 					Version string `json:"version"`
@@ -147,7 +147,7 @@ func TestRowForPod(t *testing.T) {
 		},
 		"pod with multiple containers": {
 			pod: resources.Pod{
-				StartTime: time.Now(),
+				Age: time.Now(),
 				Containers: []struct {
 					Name         string `json:"name"`
 					Ready        bool   `json:"ready"`
@@ -185,10 +185,10 @@ func testServer(t *testing.T) *httptest.Server {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf(listEndpointTemplate, "found", "env-id"):
 			pod := resources.Pod{
-				Name:      "pod-name",
-				Phase:     "running",
-				Status:    "ok",
-				StartTime: time.Now(),
+				Name:   "pod-name",
+				Phase:  "running",
+				Status: "ok",
+				Age:    time.Now(),
 				Component: []struct {
 					Name    string `json:"name"`
 					Version string `json:"version"`

--- a/internal/cmd/runtime.go
+++ b/internal/cmd/runtime.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"github.com/mia-platform/miactl/internal/clioptions"
+	cronjobs "github.com/mia-platform/miactl/internal/cmd/cronjobs/pods"
 	"github.com/mia-platform/miactl/internal/cmd/environments"
 	"github.com/mia-platform/miactl/internal/cmd/pods"
 	"github.com/spf13/cobra"
@@ -44,6 +45,7 @@ the resources generated, like Pods, Cronjobs and logs.
 	cmd.AddCommand(
 		environments.EnvironmentCmd(o),
 		pods.PodCmd(o),
+		cronjobs.CronjobCmd(o),
 	)
 
 	return cmd

--- a/internal/resources/responses.go
+++ b/internal/resources/responses.go
@@ -120,7 +120,7 @@ type Pod struct {
 	Name      string    `json:"name"`
 	Phase     string    `json:"phase"`
 	Status    string    `json:"status"`
-	StartTime time.Time `json:"startTime"`
+	Age       time.Time `json:"startTime"` //nolint:tagliatelle
 	Component []struct {
 		Name    string `json:"name"`
 		Version string `json:"version"`

--- a/internal/resources/responses.go
+++ b/internal/resources/responses.go
@@ -132,3 +132,12 @@ type Pod struct {
 		Status       string `json:"status"`
 	} `json:"containers"`
 }
+
+type CronJob struct {
+	Name         string    `json:"name"`
+	Active       int       `json:"active"`
+	Suspend      bool      `json:"suspend"`
+	Schedule     string    `json:"schedule"`
+	Age          time.Time `json:"creationTimestamp"` //nolint: tagliatelle
+	LastSchedule time.Time `json:"lastScheduleTime"`  //nolint: tagliatelle
+}


### PR DESCRIPTION
This PR will implement the new `resource cronjob list` sub command. It will show the same data that the console is showing in a table form.

I also change the property `StartTime` inside the `Pod` resource to be `Age` and use it also for the new `CronJob` resource to better indicate it's usage and be the same of the table column.