### PR TITLE
Add runtime deployment list subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - pod list command
 - cronjob list command
 - job list command
+- deployment list command
 - version command
 
 ## [0.7.0] - 2023-06-26

--- a/docs/30_commands.md
+++ b/docs/30_commands.md
@@ -257,6 +257,26 @@ Available flags for the command:
 - `--company-id`, to set the ID of the desired Company
 - `--project-id`, to set the ID of the desired Project
 
+### deployment list
+
+The `runtime deployment list` subcommand allows you to see all deployments that are running for the environment
+associated to a given Project.
+
+Usage:
+
+```sh
+miactl runtime deployment list ENVIRONMENT [flags]
+```
+
+Available flags for the command:
+
+- `--endpoint`, to set the Console endpoint (default is `https://console.cloud.mia-platform.eu`)
+- `--certificate-authority`, to provide the path to a custom CA certificate
+- `--insecure-skip-tls-verify`, to disallow the check the validity of the certificate of the remote endpoint
+- `--context`, to specify a different context from the currently selected one
+- `--company-id`, to set the ID of the desired Company
+- `--project-id`, to set the ID of the desired Project
+
 ## marketplace
 
 View and manage Marketplace items

--- a/internal/cmd/deployments/deployments.go
+++ b/internal/cmd/deployments/deployments.go
@@ -1,0 +1,129 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployments
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/mia-platform/miactl/internal/client"
+	"github.com/mia-platform/miactl/internal/clioptions"
+	"github.com/mia-platform/miactl/internal/resources"
+	"github.com/mia-platform/miactl/internal/util"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+const (
+	listEndpointTemplate = "/api/projects/%s/environments/%s/deployments/describe/"
+)
+
+func Command(o *clioptions.CLIOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deployment",
+		Short: "Manage Mia-Platform Console project runtime deployment resources",
+		Long: `Manage Mia-Platform Console project runtime deployment resources.
+
+A project on Mia-Platform Console once deployed can have one or more deployment resources associcated with one or more
+of its environments.
+`,
+	}
+
+	// add sub commands
+	cmd.AddCommand(
+		listCmd(o),
+	)
+
+	return cmd
+}
+
+func listCmd(o *clioptions.CLIOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list ENVIRONMENT",
+		Short: "List all deployments for a project in an environment",
+		Long:  "List all deployments for a project in an environment.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			restConfig, err := o.ToRESTConfig()
+			cobra.CheckErr(err)
+			client, err := client.APIClientForConfig(restConfig)
+			cobra.CheckErr(err)
+			return printDeploymentsList(client, restConfig.ProjectID, args[0])
+		},
+	}
+
+	return cmd
+}
+
+func printDeploymentsList(client *client.APIClient, projectID, environment string) error {
+	if projectID == "" {
+		return fmt.Errorf("missing project id, please set one with the flag or context")
+	}
+	resp, err := client.
+		Get().
+		APIPath(fmt.Sprintf(listEndpointTemplate, projectID, environment)).
+		Do(context.Background())
+
+	if err != nil {
+		return err
+	}
+
+	if err := resp.Error(); err != nil {
+		return err
+	}
+
+	deployments := make([]resources.Deployment, 0)
+	err = resp.ParseResponse(&deployments)
+	if err != nil {
+		return err
+	}
+
+	if len(deployments) == 0 {
+		fmt.Printf("No deployments found for %s environment\n", environment)
+		return nil
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetBorders(tablewriter.Border{Left: false, Top: false, Right: false, Bottom: false})
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeader([]string{"Name", "Ready", "Up-to-Date", "Available", "Age"})
+
+	if err != nil {
+		return err
+	}
+
+	for _, deployment := range deployments {
+		table.Append(rowForDeployment(deployment))
+	}
+
+	table.Render()
+	return nil
+}
+
+func rowForDeployment(deployment resources.Deployment) []string {
+	return []string{
+		deployment.Name,
+		fmt.Sprintf("%d/%d", deployment.Ready, deployment.Available),
+		fmt.Sprint(deployment.Replicas),
+		fmt.Sprint(deployment.Available),
+		util.HumanDuration(time.Since(deployment.Age)),
+	}
+}

--- a/internal/cmd/deployments/deployments_test.go
+++ b/internal/cmd/deployments/deployments_test.go
@@ -1,0 +1,131 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployments
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mia-platform/miactl/internal/client"
+	"github.com/mia-platform/miactl/internal/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintDeploymentsList(t *testing.T) {
+	testCases := map[string]struct {
+		testServer *httptest.Server
+		projectID  string
+		err        bool
+	}{
+		"list deployment with success": {
+			testServer: testServer(t),
+			projectID:  "found",
+		},
+		"list deployment with empty response": {
+			testServer: testServer(t),
+			projectID:  "empty",
+		},
+		"failed request": {
+			testServer: testServer(t),
+			projectID:  "fail",
+			err:        true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			server := testCase.testServer
+			defer server.Close()
+
+			client, err := client.APIClientForConfig(&client.Config{
+				Host: server.URL,
+			})
+			require.NoError(t, err)
+
+			err = printDeploymentsList(client, testCase.projectID, "env-id")
+			if testCase.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRowForDeployment(t *testing.T) {
+	testCases := map[string]struct {
+		deployment  resources.Deployment
+		expectedRow []string
+	}{
+		"basic deployment": {
+			deployment: resources.Deployment{
+				Name:      "deployment-name",
+				Ready:     1,
+				Replicas:  1,
+				Available: 1,
+				Age:       time.Now().Add(-time.Hour * 24),
+			},
+			expectedRow: []string{"deployment-name", "1/1", "1", "1", "24h"},
+		},
+		"missing ready and available": {
+			deployment: resources.Deployment{
+				Name:     "deployment-name",
+				Replicas: 0,
+				Age:      time.Now().Add(-time.Hour * 24),
+			},
+			expectedRow: []string{"deployment-name", "0/0", "0", "0", "24h"},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, testCase.expectedRow, rowForDeployment(testCase.deployment))
+		})
+	}
+}
+
+func testServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf(listEndpointTemplate, "found", "env-id"):
+			deployment := resources.Deployment{
+				Name:      "deployment-name",
+				Ready:     1,
+				Replicas:  1,
+				Available: 1,
+				Age:       time.Now().Add(time.Hour * 24),
+			}
+			data, err := resources.EncodeResourceToJSON([]resources.Deployment{deployment})
+			require.NoError(t, err)
+			w.WriteHeader(http.StatusOK)
+			w.Write(data)
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf(listEndpointTemplate, "fail", "env-id"):
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf(listEndpointTemplate, "empty", "env-id"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			assert.Failf(t, "unexpected http call", "received call with method: %s uri %s", r.Method, r.RequestURI)
+		}
+	}))
+	return server
+}

--- a/internal/cmd/deployments/doc.go
+++ b/internal/cmd/deployments/doc.go
@@ -1,0 +1,17 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// deployments package contains subcommands and functions for managing deployments
+package deployments

--- a/internal/cmd/runtime.go
+++ b/internal/cmd/runtime.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"github.com/mia-platform/miactl/internal/clioptions"
 	"github.com/mia-platform/miactl/internal/cmd/cronjobs"
+	"github.com/mia-platform/miactl/internal/cmd/deployments"
 	"github.com/mia-platform/miactl/internal/cmd/environments"
 	"github.com/mia-platform/miactl/internal/cmd/jobs"
 	"github.com/mia-platform/miactl/internal/cmd/pods"
@@ -48,6 +49,7 @@ the resources generated, like Pods, Cronjobs and logs.
 		pods.Command(o),
 		cronjobs.Command(o),
 		jobs.Command(o),
+		deployments.Command(o),
 	)
 
 	return cmd

--- a/internal/resources/responses.go
+++ b/internal/resources/responses.go
@@ -151,3 +151,11 @@ type Job struct {
 	StartTime      time.Time `json:"startTime"`
 	CompletionTime time.Time `json:"completionTime"`
 }
+
+type Deployment struct {
+	Name      string    `json:"name"`
+	Available int       `json:"available"`
+	Ready     int       `json:"ready"`
+	Replicas  int       `json:"replicas"`
+	Age       time.Time `json:"creationTimestamp"` //nolint: tagliatelle
+}


### PR DESCRIPTION
This PR will add a new runtime subcommand `runtime deployment list`. This command will print all the deployments associated with a project and environment. The information shown are comparable to the ones that a possible `kubectl` command will show.