### PR TITLE
Add runtime service list subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cronjob list command
 - job list command
 - deployment list command
+- service list command
 - version command
 
 ## [0.7.0] - 2023-06-26

--- a/docs/30_commands.md
+++ b/docs/30_commands.md
@@ -277,6 +277,26 @@ Available flags for the command:
 - `--company-id`, to set the ID of the desired Company
 - `--project-id`, to set the ID of the desired Project
 
+### service list
+
+The `runtime service list` subcommand allows you to see all services that are running for the environment associated
+to a given Project.
+
+Usage:
+
+```sh
+miactl runtime service list ENVIRONMENT [flags]
+```
+
+Available flags for the command:
+
+- `--endpoint`, to set the Console endpoint (default is `https://console.cloud.mia-platform.eu`)
+- `--certificate-authority`, to provide the path to a custom CA certificate
+- `--insecure-skip-tls-verify`, to disallow the check the validity of the certificate of the remote endpoint
+- `--context`, to specify a different context from the currently selected one
+- `--company-id`, to set the ID of the desired Company
+- `--project-id`, to set the ID of the desired Project
+
 ## marketplace
 
 View and manage Marketplace items

--- a/internal/cmd/cronjobs/cronjobs_test.go
+++ b/internal/cmd/cronjobs/cronjobs_test.go
@@ -104,7 +104,7 @@ func testServer(t *testing.T) *httptest.Server {
 				Suspend:      true,
 				Active:       0,
 				Schedule:     "* * * * *",
-				Age:          time.Now().Add(time.Hour * 24),
+				Age:          time.Now().Add(-time.Hour * 24),
 				LastSchedule: time.Now(),
 			}
 			data, err := resources.EncodeResourceToJSON([]resources.CronJob{cronjob})

--- a/internal/cmd/runtime.go
+++ b/internal/cmd/runtime.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mia-platform/miactl/internal/cmd/environments"
 	"github.com/mia-platform/miactl/internal/cmd/jobs"
 	"github.com/mia-platform/miactl/internal/cmd/pods"
+	"github.com/mia-platform/miactl/internal/cmd/services"
 	"github.com/spf13/cobra"
 )
 
@@ -50,6 +51,7 @@ the resources generated, like Pods, Cronjobs and logs.
 		cronjobs.Command(o),
 		jobs.Command(o),
 		deployments.Command(o),
+		services.Command(o),
 	)
 
 	return cmd

--- a/internal/cmd/services/doc.go
+++ b/internal/cmd/services/doc.go
@@ -1,0 +1,17 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// services package contains subcommands and functions for managing services
+package services

--- a/internal/cmd/services/services.go
+++ b/internal/cmd/services/services.go
@@ -1,0 +1,140 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/mia-platform/miactl/internal/client"
+	"github.com/mia-platform/miactl/internal/clioptions"
+	"github.com/mia-platform/miactl/internal/resources"
+	"github.com/mia-platform/miactl/internal/util"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+const (
+	listEndpointTemplate = "/api/projects/%s/environments/%s/services/describe/"
+)
+
+func Command(o *clioptions.CLIOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "service",
+		Short: "Manage Mia-Platform Console project runtime service resources",
+		Long: `Manage Mia-Platform Console project runtime service resources.
+
+A project on Mia-Platform Console once deployed can have one or more service resources associcated with one or more
+of its environments.
+`,
+	}
+
+	// add sub commands
+	cmd.AddCommand(
+		listCmd(o),
+	)
+
+	return cmd
+}
+
+func listCmd(o *clioptions.CLIOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list ENVIRONMENT",
+		Short: "List all services for a project in an environment",
+		Long:  "List all services for a project in an environment.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			restConfig, err := o.ToRESTConfig()
+			cobra.CheckErr(err)
+			client, err := client.APIClientForConfig(restConfig)
+			cobra.CheckErr(err)
+			return printServicesList(client, restConfig.ProjectID, args[0])
+		},
+	}
+
+	return cmd
+}
+
+func printServicesList(client *client.APIClient, projectID, environment string) error {
+	if projectID == "" {
+		return fmt.Errorf("missing project id, please set one with the flag or context")
+	}
+	resp, err := client.
+		Get().
+		APIPath(fmt.Sprintf(listEndpointTemplate, projectID, environment)).
+		Do(context.Background())
+
+	if err != nil {
+		return err
+	}
+
+	if err := resp.Error(); err != nil {
+		return err
+	}
+
+	services := make([]resources.Service, 0)
+	err = resp.ParseResponse(&services)
+	if err != nil {
+		return err
+	}
+
+	if len(services) == 0 {
+		fmt.Printf("No services found for %s environment\n", environment)
+		return nil
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetBorders(tablewriter.Border{Left: false, Top: false, Right: false, Bottom: false})
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeader([]string{"Name", "Type", "Cluster-IP", "Port(s)", "Age"})
+
+	if err != nil {
+		return err
+	}
+
+	for _, service := range services {
+		table.Append(rowForService(service))
+	}
+
+	table.Render()
+	return nil
+}
+
+func rowForService(service resources.Service) []string {
+	ports := make([]string, 0)
+	for _, port := range service.Ports {
+		ports = append(ports, fmt.Sprintf("%d/%s", port.Port, port.Protocol))
+	}
+
+	clusterIP := service.ClusterIP
+	if len(clusterIP) == 0 {
+		clusterIP = "<none>"
+	}
+
+	return []string{
+		service.Name,
+		service.Type,
+		clusterIP,
+		strings.Join(ports, ","),
+		util.HumanDuration(time.Since(service.Age)),
+	}
+}

--- a/internal/resources/responses.go
+++ b/internal/resources/responses.go
@@ -159,3 +159,18 @@ type Deployment struct {
 	Replicas  int       `json:"replicas"`
 	Age       time.Time `json:"creationTimestamp"` //nolint: tagliatelle
 }
+
+type Service struct {
+	Name      string    `json:"name"`
+	Type      string    `json:"type"`
+	ClusterIP string    `json:"clusterIP"` //nolint: tagliatelle
+	Ports     []Port    `json:"ports"`
+	Age       time.Time `json:"creationTimestamp"` //nolint: tagliatelle
+}
+
+type Port struct {
+	Name       string `json:"name"`
+	Port       int    `json:"port"`
+	Protocol   string `json:"protocol"`
+	TargetPort string `json:"targetPort"`
+}


### PR DESCRIPTION
This PR will introduce the new runtime subcommand `runtime service list`. It will show if one or more services are present in the chosen project and environment.

It will show a similar output as `kubectl get services`.