### PR TITLE
Add runtime events command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - job list command
 - deployment list command
 - service list command
+- events command
 - version command
 
 ## [0.7.0] - 2023-06-26

--- a/docs/30_commands.md
+++ b/docs/30_commands.md
@@ -297,6 +297,26 @@ Available flags for the command:
 - `--company-id`, to set the ID of the desired Company
 - `--project-id`, to set the ID of the desired Project
 
+### events
+
+The `runtime events` subcommand allows you to see events that are associated with the specific resource in the
+given environment.
+
+Usage:
+
+```sh
+miactl runtime events ENVIRONMENT RESOURCE-NAME [flags]
+```
+
+Available flags for the command:
+
+- `--endpoint`, to set the Console endpoint (default is `https://console.cloud.mia-platform.eu`)
+- `--certificate-authority`, to provide the path to a custom CA certificate
+- `--insecure-skip-tls-verify`, to disallow the check the validity of the certificate of the remote endpoint
+- `--context`, to specify a different context from the currently selected one
+- `--company-id`, to set the ID of the desired Company
+- `--project-id`, to set the ID of the desired Project
+
 ## marketplace
 
 View and manage Marketplace items

--- a/internal/cmd/events/deployments_test.go
+++ b/internal/cmd/events/deployments_test.go
@@ -1,0 +1,135 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mia-platform/miactl/internal/client"
+	"github.com/mia-platform/miactl/internal/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintEventsList(t *testing.T) {
+	testCases := map[string]struct {
+		testServer *httptest.Server
+		projectID  string
+		err        bool
+	}{
+		"list event with success": {
+			testServer: testServer(t),
+			projectID:  "found",
+		},
+		"list event with empty response": {
+			testServer: testServer(t),
+			projectID:  "empty",
+		},
+		"failed request": {
+			testServer: testServer(t),
+			projectID:  "fail",
+			err:        true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			server := testCase.testServer
+			defer server.Close()
+
+			client, err := client.APIClientForConfig(&client.Config{
+				Host: server.URL,
+			})
+			require.NoError(t, err)
+
+			err = printEventsList(client, testCase.projectID, "env-id", "resource")
+			if testCase.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRowForEvent(t *testing.T) {
+	testCases := map[string]struct {
+		event       resources.RuntimeEvent
+		expectedRow []string
+	}{
+		"basic event": {
+			event: resources.RuntimeEvent{
+				Type:      "Warning",
+				FirstSeen: time.Now().Add(-time.Hour * 24),
+				LastSeen:  time.Now().Add(-time.Hour * 12),
+				Message:   "Message test",
+				Reason:    "Reason",
+				Object:    "Object",
+			},
+			expectedRow: []string{"12h", "Warning", "Reason", "Object", "Message test"},
+		},
+		"missing last seend": {
+			event: resources.RuntimeEvent{
+				Type:      "Warning",
+				FirstSeen: time.Now().Add(-time.Hour * 24),
+				Message:   "Message test",
+				Reason:    "Reason",
+				Object:    "Object",
+			},
+			expectedRow: []string{"24h", "Warning", "Reason", "Object", "Message test"},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, testCase.expectedRow, rowForEvent(testCase.event))
+		})
+	}
+}
+
+func testServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf(eventsEndpointTemplate, "found", "env-id", "resource"):
+			event := resources.RuntimeEvent{
+				Type:      "Warning",
+				FirstSeen: time.Now().Add(-time.Hour * 24),
+				LastSeen:  time.Now().Add(-time.Hour * 12),
+				Message:   "Message test",
+				Reason:    "Reason",
+				Object:    "Resource object definition",
+			}
+			data, err := resources.EncodeResourceToJSON([]resources.RuntimeEvent{event})
+			require.NoError(t, err)
+			w.WriteHeader(http.StatusOK)
+			w.Write(data)
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf(eventsEndpointTemplate, "fail", "env-id", "resource"):
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf(eventsEndpointTemplate, "empty", "env-id", "resource"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			assert.Failf(t, "unexpected http call", "received call with method: %s uri %s", r.Method, r.RequestURI)
+		}
+	}))
+	return server
+}

--- a/internal/cmd/events/doc.go
+++ b/internal/cmd/events/doc.go
@@ -1,0 +1,17 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// events package contains subcommands and functions for managing events
+package events

--- a/internal/cmd/events/events.go
+++ b/internal/cmd/events/events.go
@@ -1,0 +1,116 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/mia-platform/miactl/internal/client"
+	"github.com/mia-platform/miactl/internal/clioptions"
+	"github.com/mia-platform/miactl/internal/resources"
+	"github.com/mia-platform/miactl/internal/util"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+const (
+	eventsEndpointTemplate = "/api/projects/%s/environments/%s/resources/%s/events"
+)
+
+func Command(o *clioptions.CLIOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "events ENVIRONMENT RESOURCE-NAME",
+		Short: "Show events related to a runtime resource in a Mia-Platform Console project environment",
+		Long:  "Show events related to a runtime resource in a Mia-Platform Console project environment.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			restConfig, err := o.ToRESTConfig()
+			cobra.CheckErr(err)
+			client, err := client.APIClientForConfig(restConfig)
+			cobra.CheckErr(err)
+			return printEventsList(client, restConfig.ProjectID, args[0], args[1])
+		},
+	}
+	return cmd
+}
+
+func printEventsList(client *client.APIClient, projectID, environment, resourceName string) error {
+	if projectID == "" {
+		return fmt.Errorf("missing project id, please set one with the flag or context")
+	}
+	resp, err := client.
+		Get().
+		APIPath(fmt.Sprintf(eventsEndpointTemplate, projectID, environment, resourceName)).
+		Do(context.Background())
+
+	if err != nil {
+		return err
+	}
+
+	if err := resp.Error(); err != nil {
+		return err
+	}
+
+	events := make([]resources.RuntimeEvent, 0)
+	err = resp.ParseResponse(&events)
+	if err != nil {
+		return err
+	}
+
+	if len(events) == 0 {
+		fmt.Printf("No events found for %s in %s environment\n", resourceName, environment)
+		return nil
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetBorders(tablewriter.Border{Left: false, Top: false, Right: false, Bottom: false})
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetAutoWrapText(false)
+	table.SetHeader([]string{"Last Seen", "Type", "Reason", "Object", "Message"})
+
+	if err != nil {
+		return err
+	}
+
+	for _, event := range events {
+		table.Append(rowForEvent(event))
+	}
+
+	table.Render()
+	return nil
+}
+
+func rowForEvent(event resources.RuntimeEvent) []string {
+	age := "-"
+	if !event.LastSeen.IsZero() {
+		age = util.HumanDuration(time.Since(event.LastSeen))
+	} else if !event.FirstSeen.IsZero() {
+		age = util.HumanDuration(time.Since(event.FirstSeen))
+	}
+	return []string{
+		age,
+		event.Type,
+		event.Reason,
+		event.Object,
+		event.Message,
+	}
+}

--- a/internal/cmd/runtime.go
+++ b/internal/cmd/runtime.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mia-platform/miactl/internal/cmd/cronjobs"
 	"github.com/mia-platform/miactl/internal/cmd/deployments"
 	"github.com/mia-platform/miactl/internal/cmd/environments"
+	"github.com/mia-platform/miactl/internal/cmd/events"
 	"github.com/mia-platform/miactl/internal/cmd/jobs"
 	"github.com/mia-platform/miactl/internal/cmd/pods"
 	"github.com/mia-platform/miactl/internal/cmd/services"
@@ -52,6 +53,7 @@ the resources generated, like Pods, Cronjobs and logs.
 		jobs.Command(o),
 		deployments.Command(o),
 		services.Command(o),
+		events.Command(o),
 	)
 
 	return cmd

--- a/internal/resources/responses.go
+++ b/internal/resources/responses.go
@@ -174,3 +174,12 @@ type Port struct {
 	Protocol   string `json:"protocol"`
 	TargetPort string `json:"targetPort"`
 }
+
+type RuntimeEvent struct {
+	Type      string    `json:"type"`
+	Object    string    `json:"subObjectPath"` //nolint: tagliatelle
+	Message   string    `json:"message"`
+	Reason    string    `json:"reason"`
+	FirstSeen time.Time `json:"firstSeen"`
+	LastSeen  time.Time `json:"lastSeen"`
+}


### PR DESCRIPTION
New events subcommand for `runtime`, it can show related events to resources in a specific environment of a project. The output is similar to the one of `kubectl get envents`.