### PR TITLE
fix: version help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- help text of version command
+
 ## [0.9.0] - 2023-11-15
 
 ### Added

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -37,8 +37,8 @@ func VersionCmd(_ *clioptions.CLIOptions) *cobra.Command {
 	// Version subcommand
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Show mlp version",
-		Long:  "Show mlp version",
+		Short: "Show miactl version",
+		Long:  "Show miactl version",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println(versionOutput)
 		},


### PR DESCRIPTION
## What this PR is for?

Fix the help text of the `version` command, replacing `mlp` with `miactl`