### PR TITLE
fix: marketplace apply should silently ignore unsupported files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - help text of version command
+- marketplace apply: silently ignore files with invalid extension rather than throwing error
 
 ## [0.9.0] - 2023-11-15
 

--- a/internal/cmd/marketplace/apply/apply.go
+++ b/internal/cmd/marketplace/apply/apply.go
@@ -242,12 +242,11 @@ func buildApplyRequest(pathList []string) (*marketplace.ApplyRequest, map[string
 		if err != nil {
 			return nil, nil, err
 		}
-		switch filepath.Ext(filepath.Ext(filePath)) {
-		case encoding.YmlExtension, encoding.YamlExtension, encoding.JSONExtension:
-			break
-		default:
-			return nil, nil, fmt.Errorf("%w: %s", errInvalidExtension, filePath)
+
+		if !isSupportedExtension(filepath.Ext(filePath)) {
+			continue
 		}
+
 		marketplaceItem := &marketplace.Item{}
 		err = encoding.UnmarshalData(content, marketplaceItem)
 		if err != nil {
@@ -275,6 +274,14 @@ func buildApplyRequest(pathList []string) (*marketplace.ApplyRequest, map[string
 	return &marketplace.ApplyRequest{
 		Resources: resources,
 	}, resItemIDToFilePath, nil
+}
+
+func isSupportedExtension(ext string) bool {
+	switch ext {
+	case encoding.YmlExtension, encoding.YamlExtension, encoding.JSONExtension:
+		return true
+	}
+	return false
 }
 
 func validateItemName(marketplaceItem *marketplace.Item, filePath string) (string, error) {

--- a/internal/cmd/marketplace/apply/apply_test.go
+++ b/internal/cmd/marketplace/apply/apply_test.go
@@ -102,7 +102,7 @@ func TestApplyBuildApplyRequest(t *testing.T) {
 		require.Nil(t, foundResNameToFilePath)
 	})
 
-	t.Run("should return error if a file has unknown extensions, but others are valid", func(t *testing.T) {
+	t.Run("should ignore a file it it has unknown extensions, and should parse only valid files", func(t *testing.T) {
 		filePaths := []string{
 			"./testdata/someFileNotYamlNotJson.txt",
 			"./testdata/validItem1.json",
@@ -110,13 +110,28 @@ func TestApplyBuildApplyRequest(t *testing.T) {
 		}
 
 		foundApplyReq, foundResNameToFilePath, err := buildApplyRequest(filePaths)
-		require.ErrorIs(t, err, errInvalidExtension)
-		require.Nil(t, foundApplyReq)
-		require.Nil(t, foundResNameToFilePath)
+		require.NoError(t, err)
+		require.NotNil(t, foundApplyReq)
+		require.Len(t, foundApplyReq.Resources, 2)
+		require.Equal(t, foundResNameToFilePath, map[string]string{
+			"miactl-test-json": "./testdata/validItem1.json",
+			"miactl-test":      "./testdata/validYaml.yaml",
+		})
 	})
 
 	t.Run("should return error if resources array is empty", func(t *testing.T) {
 		filePaths := []string{}
+
+		foundApplyReq, foundResNameToFilePath, err := buildApplyRequest(filePaths)
+		require.ErrorIs(t, err, errNoValidFilesProvided)
+		require.Nil(t, foundApplyReq)
+		require.Nil(t, foundResNameToFilePath)
+	})
+
+	t.Run("should return error if resources are all with invalid file extension", func(t *testing.T) {
+		filePaths := []string{
+			"./testdata/someFileNotYamlNotJson.txt",
+		}
 
 		foundApplyReq, foundResNameToFilePath, err := buildApplyRequest(filePaths)
 		require.ErrorIs(t, err, errNoValidFilesProvided)


### PR DESCRIPTION

## What this PR is for?
marketplace apply: silently ignore files with invalid extension rather than throwing error

