### PR TITLE
feat: marketplace delete item by itemId+version tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - marketplace apply: consider both itemId and version for duplicate check
 - marketplace apply: silently ignore files with invalid extension rather than throwing error
 
+### Updated
+
+- modified `miactl marketplace delete` command to accept either the `objectId` or a `itemId`-`version` tuple that identifies the item to be deleted.
+
+### BREAKING
+
+- `miactl marketplace delete` does not accept anymore the id as argument, it should be provided to the flag `--object-id`
+
 ## [0.9.0] - 2023-11-15
 
 ### Added

--- a/docs/30_commands.md
+++ b/docs/30_commands.md
@@ -343,10 +343,17 @@ Delete a Marketplace item
 
 #### Synopsis
 
-Delete a single Marketplace item by its ID
+Delete a single Marketplace item
+
+You need to specify either:
+- the itemId and the version, respectively  (recommended)
+- the ObjectID of the item with the flag object-id
+
+Passing the ObjectID is expected only when dealing with deprecated Marketplace items missing the itemId and/or version fields.
+Otherwise, it is preferable to pass the tuple itemId-version.
 
 ```
-miactl marketplace delete resource-id [flags]
+miactl marketplace delete --item-id some-item --version '1.0.0'
 ```
 
 ### apply

--- a/internal/clioptions/clioptions.go
+++ b/internal/clioptions/clioptions.go
@@ -53,8 +53,8 @@ type CLIOptions struct {
 	OutputPath         string
 
 	MarketplaceResourcePaths []string
-	// MarketplaceItemItemID is the itemId field of a Marketplace item
-	MarketplaceItemItemID string
+	// MarketplaceItemID is the itemId field of a Marketplace item
+	MarketplaceItemID string
 	// MarketplaceItemVersion is the version field of a Marketplace item
 	MarketplaceItemVersion string
 	// MarketplaceItemObjectID is the _id of a Marketplace item
@@ -141,9 +141,9 @@ func (o *CLIOptions) AddMarketplaceApplyFlags(cmd *cobra.Command) {
 	}
 }
 
-func (o *CLIOptions) AddMarketplaceItemItemIDFlag(flags *pflag.FlagSet) (flagName string) {
+func (o *CLIOptions) AddMarketplaceItemIDFlag(flags *pflag.FlagSet) (flagName string) {
 	flagName = "item-id"
-	flags.StringVarP(&o.MarketplaceItemItemID, flagName, "i", "", "The itemId of the Marketplace item")
+	flags.StringVarP(&o.MarketplaceItemID, flagName, "i", "", "The itemId of the Marketplace item")
 	return
 }
 

--- a/internal/clioptions/clioptions.go
+++ b/internal/clioptions/clioptions.go
@@ -53,7 +53,12 @@ type CLIOptions struct {
 	OutputPath         string
 
 	MarketplaceResourcePaths []string
-	MarketplaceItemID        string
+	// MarketplaceItemItemID is the itemId field of a Marketplace item
+	MarketplaceItemItemID string
+	// MarketplaceItemVersion is the version field of a Marketplace item
+	MarketplaceItemVersion string
+	// MarketplaceItemObjectID is the _id of a Marketplace item
+	MarketplaceItemObjectID string
 
 	FromCronJob string
 
@@ -136,10 +141,22 @@ func (o *CLIOptions) AddMarketplaceApplyFlags(cmd *cobra.Command) {
 	}
 }
 
-func (o *CLIOptions) AddMarketplaceGetItemVersionsFlags(cmd *cobra.Command) string {
-	flagName := "item-id"
-	cmd.Flags().StringVarP(&o.MarketplaceItemID, flagName, "i", "", "The itemId of the item")
-	return flagName
+func (o *CLIOptions) AddMarketplaceItemItemIDFlag(flags *pflag.FlagSet) (flagName string) {
+	flagName = "item-id"
+	flags.StringVarP(&o.MarketplaceItemItemID, flagName, "i", "", "The itemId of the Marketplace item")
+	return
+}
+
+func (o *CLIOptions) AddMarketplaceItemObjectIDFlag(flags *pflag.FlagSet) (flagName string) {
+	flagName = "object-id"
+	flags.StringVar(&o.MarketplaceItemObjectID, flagName, "", "The _id of the Marketplace item")
+	return
+}
+
+func (o *CLIOptions) AddMarketplaceVersionFlag(flags *pflag.FlagSet) (flagName string) {
+	flagName = "version"
+	flags.StringVarP(&o.MarketplaceItemVersion, flagName, "v", "", "The version of the Marketplace item")
+	return
 }
 
 func (o *CLIOptions) AddCreateJobFlags(flags *pflag.FlagSet) {

--- a/internal/cmd/marketplace/delete.go
+++ b/internal/cmd/marketplace/delete.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-	// deleteMarketplaceEndpointTemplate formatting template for item deletion by objectID backend endpoint; specify tenantID, objectID
-	deleteMarketplaceEndpointTemplate = "/api/backend/marketplace/tenants/%s/resources/%s"
+	// deleteItemEndpointTemplate formatting template for item deletion by objectID backend endpoint; specify tenantID, objectID
+	deleteItemEndpointTemplate = "/api/backend/marketplace/tenants/%s/resources/%s"
 	// deleteItemByTupleEndpointTemplate formatting template for item deletion by the tuple itemID versionID endpoint; specify companyID, itemID, version
 	deleteItemByTupleEndpointTemplate = "/api/backend/marketplace/tenants/%s/resources/%s/versions/%s"
 )
@@ -42,12 +42,16 @@ var (
 // DeleteCmd return a new cobra command for deleting a single marketplace resource
 func DeleteCmd(options *clioptions.CLIOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete ",
-		Short: "Delete Marketplace item",
-		Long: `Delete a single Marketplace item by its ID
+		Use:   "delete { -i item-id -v version } | --object-id object-id",
+		Short: "Delete a Marketplace item",
+		Long: `Delete a single Marketplace item
+
 You need to specify either:
-- the itemId and the version with the respective flags
+- the itemId and the version, respectively  (recommended)
 - the ObjectID of the item with the flag object-id
+
+Passing the ObjectID is expected only when dealing with deprecated Marketplace items missing the itemId and/or version fields.
+Otherwise, it is preferable to pass the tuple itemId-version.
 `,
 		SuggestFor: []string{"rm"},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -98,7 +102,7 @@ You need to specify either:
 func deleteItemByObjectID(ctx context.Context, client *client.APIClient, companyID, objectID string) error {
 	resp, err := client.
 		Delete().
-		APIPath(fmt.Sprintf(deleteMarketplaceEndpointTemplate, companyID, objectID)).
+		APIPath(fmt.Sprintf(deleteItemEndpointTemplate, companyID, objectID)).
 		Do(ctx)
 
 	if err != nil {

--- a/internal/cmd/marketplace/delete.go
+++ b/internal/cmd/marketplace/delete.go
@@ -42,7 +42,7 @@ var (
 // DeleteCmd return a new cobra command for deleting a single marketplace resource
 func DeleteCmd(options *clioptions.CLIOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete { -i item-id -v version } | --object-id object-id",
+		Use:   "delete { -i item-id -v version } | --object-id object-id [flags]...",
 		Short: "Delete a Marketplace item",
 		Long: `Delete a single Marketplace item
 

--- a/internal/cmd/marketplace/delete.go
+++ b/internal/cmd/marketplace/delete.go
@@ -71,12 +71,12 @@ Otherwise, it is preferable to pass the tuple itemId-version.
 				return nil
 			}
 
-			if options.MarketplaceItemVersion != "" && options.MarketplaceItemItemID != "" {
+			if options.MarketplaceItemVersion != "" && options.MarketplaceItemID != "" {
 				err = deleteItemByItemIDAndVersion(
 					cmd.Context(),
 					client,
 					companyID,
-					options.MarketplaceItemItemID,
+					options.MarketplaceItemID,
 					options.MarketplaceItemVersion,
 				)
 				cobra.CheckErr(err)
@@ -87,7 +87,7 @@ Otherwise, it is preferable to pass the tuple itemId-version.
 		},
 	}
 
-	itemIDFlagName := options.AddMarketplaceItemItemIDFlag(cmd.Flags())
+	itemIDFlagName := options.AddMarketplaceItemIDFlag(cmd.Flags())
 	versionFlagName := options.AddMarketplaceVersionFlag(cmd.Flags())
 	itemObjectIDFlagName := options.AddMarketplaceItemObjectIDFlag(cmd.Flags())
 

--- a/internal/cmd/marketplace/delete_test.go
+++ b/internal/cmd/marketplace/delete_test.go
@@ -45,7 +45,7 @@ func deleteByIDMockServer(t *testing.T, statusCode int) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t,
-			fmt.Sprintf(deleteMarketplaceEndpointTemplate, mockDeleteCompanyID, mockDeleteObjectID),
+			fmt.Sprintf(deleteItemEndpointTemplate, mockDeleteCompanyID, mockDeleteObjectID),
 			r.RequestURI,
 		)
 		require.Equal(t, http.MethodDelete, r.Method)

--- a/internal/cmd/marketplace/delete_test.go
+++ b/internal/cmd/marketplace/delete_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-	mockDeleteResourceID = "resource-id"
-	mockDeleteCompanyID  = "company-id"
+	mockDeleteObjectID  = "object-id"
+	mockDeleteCompanyID = "company-id"
 )
 
 func TestDeleteResourceCmd(t *testing.T) {
@@ -43,7 +43,7 @@ func TestDeleteResourceCmd(t *testing.T) {
 func deleteByIDMockServer(t *testing.T, statusCode int) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI != fmt.Sprintf(deleteMarketplaceEndpoint, mockDeleteCompanyID, mockDeleteResourceID) && r.Method != http.MethodDelete {
+		if r.RequestURI != fmt.Sprintf(deleteMarketplaceEndpointTemplate, mockDeleteCompanyID, mockDeleteObjectID) && r.Method != http.MethodDelete {
 			w.WriteHeader(http.StatusNotFound)
 			require.Fail(t, "unsupported call")
 			return
@@ -52,7 +52,7 @@ func deleteByIDMockServer(t *testing.T, statusCode int) *httptest.Server {
 	}))
 }
 
-func TestDeleteResourceById(t *testing.T) {
+func TestDeleteItemByObjectId(t *testing.T) {
 	testCases := map[string]struct {
 		server       *httptest.Server
 		clientConfig *client.Config
@@ -101,7 +101,7 @@ func TestDeleteResourceById(t *testing.T) {
 			testCase.clientConfig.Host = testCase.server.URL
 			client, err := client.APIClientForConfig(testCase.clientConfig)
 			require.NoError(t, err)
-			err = deleteMarketplaceResource(client, mockDeleteCompanyID, mockDeleteResourceID)
+			err = deleteItemByObjectID(client, mockDeleteCompanyID, mockDeleteObjectID)
 			if testCase.err {
 				assert.Error(t, err)
 			} else {

--- a/internal/cmd/marketplace/delete_test.go
+++ b/internal/cmd/marketplace/delete_test.go
@@ -50,6 +50,13 @@ func deleteByIDMockServer(t *testing.T, statusCode int) *httptest.Server {
 		)
 		require.Equal(t, http.MethodDelete, r.Method)
 		w.WriteHeader(statusCode)
+		if statusCode != http.StatusNoContent {
+			w.Write([]byte(`
+			{
+				"message": "some error message"
+			}
+			`))
+		}
 	}))
 }
 
@@ -66,6 +73,13 @@ func deleteByItemIDAndVersionMockServer(t *testing.T,
 		)
 		require.Equal(t, http.MethodDelete, r.Method)
 		w.WriteHeader(statusCode)
+		if statusCode != http.StatusNoContent {
+			w.Write([]byte(`
+			{
+				"message": "some error message"
+			}
+			`))
+		}
 		*callsCount++
 	}))
 }

--- a/internal/cmd/marketplace/delete_test.go
+++ b/internal/cmd/marketplace/delete_test.go
@@ -16,6 +16,7 @@
 package marketplace
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -23,7 +24,7 @@ import (
 
 	"github.com/mia-platform/miactl/internal/client"
 	"github.com/mia-platform/miactl/internal/clioptions"
-	"github.com/stretchr/testify/assert"
+	"github.com/mia-platform/miactl/internal/resources/marketplace"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,69 +44,174 @@ func TestDeleteResourceCmd(t *testing.T) {
 func deleteByIDMockServer(t *testing.T, statusCode int) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.RequestURI != fmt.Sprintf(deleteMarketplaceEndpointTemplate, mockDeleteCompanyID, mockDeleteObjectID) && r.Method != http.MethodDelete {
-			w.WriteHeader(http.StatusNotFound)
-			require.Fail(t, "unsupported call")
-			return
-		}
+		require.Equal(t,
+			fmt.Sprintf(deleteMarketplaceEndpointTemplate, mockDeleteCompanyID, mockDeleteObjectID),
+			r.RequestURI,
+		)
+		require.Equal(t, http.MethodDelete, r.Method)
 		w.WriteHeader(statusCode)
 	}))
 }
 
+func deleteByItemIDAndVersionMockServer(t *testing.T,
+	statusCode int,
+	mockItemID, mockVersion string,
+	callsCount *int,
+) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t,
+			fmt.Sprintf(deleteItemByTupleEndpointTemplate, mockDeleteCompanyID, mockItemID, mockVersion),
+			r.RequestURI,
+		)
+		require.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(statusCode)
+		*callsCount++
+	}))
+}
+
 func TestDeleteItemByObjectId(t *testing.T) {
+	mockClientConfig := &client.Config{
+		Transport: http.DefaultTransport,
+	}
 	testCases := map[string]struct {
-		server       *httptest.Server
-		clientConfig *client.Config
-		err          bool
+		server      *httptest.Server
+		expectedErr error
 	}{
 		"valid delete response": {
-			server: deleteByIDMockServer(t, http.StatusNoContent),
-			clientConfig: &client.Config{
-				Transport: http.DefaultTransport,
-			},
-			err: false,
+			server:      deleteByIDMockServer(t, http.StatusNoContent),
+			expectedErr: nil,
 		},
 		"resource not found": {
-			server: deleteByIDMockServer(t, http.StatusNotFound),
-			clientConfig: &client.Config{
-				Transport: http.DefaultTransport,
-			},
-			err: true,
+			server:      deleteByIDMockServer(t, http.StatusNotFound),
+			expectedErr: marketplace.ErrItemNotFound,
 		},
 		"internal server error": {
-			server: deleteByIDMockServer(t, http.StatusInternalServerError),
-			clientConfig: &client.Config{
-				Transport: http.DefaultTransport,
-			},
-			err: true,
+			server:      deleteByIDMockServer(t, http.StatusInternalServerError),
+			expectedErr: errServerDeleteItem,
 		},
 		"unexpected server response error": {
-			server: deleteByIDMockServer(t, http.StatusBadGateway),
-			clientConfig: &client.Config{
-				Transport: http.DefaultTransport,
-			},
-			err: true,
+			server:      deleteByIDMockServer(t, http.StatusBadGateway),
+			expectedErr: errServerDeleteItem,
 		},
 		"unexpected server response 2xx": {
-			server: deleteByIDMockServer(t, http.StatusAccepted),
-			clientConfig: &client.Config{
-				Transport: http.DefaultTransport,
-			},
-			err: true,
+			server:      deleteByIDMockServer(t, http.StatusAccepted),
+			expectedErr: errUnexpectedDeleteItem,
+		},
+		"unexpected server response 4xx": {
+			server:      deleteByIDMockServer(t, http.StatusBadRequest),
+			expectedErr: errUnexpectedDeleteItem,
 		},
 	}
 
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
 			defer testCase.server.Close()
-			testCase.clientConfig.Host = testCase.server.URL
-			client, err := client.APIClientForConfig(testCase.clientConfig)
+			mockClientConfig.Host = testCase.server.URL
+			client, err := client.APIClientForConfig(mockClientConfig)
 			require.NoError(t, err)
-			err = deleteItemByObjectID(client, mockDeleteCompanyID, mockDeleteObjectID)
-			if testCase.err {
-				assert.Error(t, err)
+			err = deleteItemByObjectID(
+				context.Background(),
+				client,
+				mockDeleteCompanyID,
+				mockDeleteObjectID,
+			)
+			if testCase.expectedErr != nil {
+				require.ErrorIs(t, err, testCase.expectedErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDeleteItemByItemIDAndVersion(t *testing.T) {
+	mockClientConfig := &client.Config{
+		Transport: http.DefaultTransport,
+	}
+	testCases := []struct {
+		testName string
+
+		statusCode int
+
+		itemID  string
+		version string
+
+		expectedErr   error
+		expectedCalls int
+	}{
+		{
+			testName:   "should not return error if deletion is successful",
+			statusCode: http.StatusNoContent,
+			itemID:     "some-id",
+			version:    "1.0.0",
+
+			expectedErr:   nil,
+			expectedCalls: 1,
+		},
+		{
+			testName: "should return not found error in case the item is not found",
+			itemID:   "some-id",
+			version:  "1.0.0",
+
+			statusCode: http.StatusNotFound,
+
+			expectedErr:   marketplace.ErrItemNotFound,
+			expectedCalls: 1,
+		},
+		{
+			testName: "should return generic error in case the server responds 500",
+			itemID:   "some-id",
+			version:  "1.0.0",
+
+			statusCode: http.StatusInternalServerError,
+
+			expectedErr:   errServerDeleteItem,
+			expectedCalls: 1,
+		},
+		{
+			testName: "should return unexpected response error in case of bad request response",
+			itemID:   "some-id",
+			version:  "1.0.0",
+
+			statusCode: http.StatusBadRequest,
+
+			expectedErr:   errUnexpectedDeleteItem,
+			expectedCalls: 1,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			callsCount := new(int)
+			*callsCount = 0
+			testServer := deleteByItemIDAndVersionMockServer(
+				t,
+				tt.statusCode,
+				tt.itemID,
+				tt.version,
+				callsCount,
+			)
+			defer testServer.Close()
+
+			mockClientConfig.Host = testServer.URL
+			client, err := client.APIClientForConfig(mockClientConfig)
+			require.NoError(t, err)
+
+			err = deleteItemByItemIDAndVersion(
+				context.Background(),
+				client,
+				mockDeleteCompanyID,
+				tt.itemID,
+				tt.version,
+			)
+
+			require.Equal(t, tt.expectedCalls, *callsCount, "did not match number of calls")
+
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/cmd/marketplace/list_versions.go
+++ b/internal/cmd/marketplace/list_versions.go
@@ -54,7 +54,7 @@ This command is in ALPHA state. This means that it can be subject to breaking ch
 			releases, err := getItemVersions(
 				client,
 				restConfig.CompanyID,
-				options.MarketplaceItemItemID,
+				options.MarketplaceItemID,
 			)
 			cobra.CheckErr(err)
 
@@ -64,7 +64,7 @@ This command is in ALPHA state. This means that it can be subject to breaking ch
 		},
 	}
 
-	flagName := options.AddMarketplaceItemItemIDFlag(cmd.Flags())
+	flagName := options.AddMarketplaceItemIDFlag(cmd.Flags())
 	err := cmd.MarkFlagRequired(flagName)
 	if err != nil {
 		// the error is only due to a programming error (missing command flag), hence panic

--- a/internal/cmd/marketplace/list_versions.go
+++ b/internal/cmd/marketplace/list_versions.go
@@ -32,7 +32,6 @@ import (
 const listItemVersionsEndpointTemplate = "/api/backend/marketplace/tenants/%s/resources/%s/versions"
 
 var (
-	ErrItemNotFound       = errors.New("item not found")
 	ErrGenericServerError = errors.New("server error while fetching item versions")
 	ErrMissingCompanyID   = errors.New("companyID is required")
 )
@@ -99,7 +98,7 @@ func getItemVersions(client *client.APIClient, companyID, itemID string) (*[]mar
 		}
 		return releases, nil
 	case http.StatusNotFound:
-		return nil, fmt.Errorf("%w: %s", ErrItemNotFound, itemID)
+		return nil, fmt.Errorf("%w: %s", marketplace.ErrItemNotFound, itemID)
 	}
 	return nil, ErrGenericServerError
 }

--- a/internal/cmd/marketplace/list_versions.go
+++ b/internal/cmd/marketplace/list_versions.go
@@ -55,7 +55,7 @@ This command is in ALPHA state. This means that it can be subject to breaking ch
 			releases, err := getItemVersions(
 				client,
 				restConfig.CompanyID,
-				options.MarketplaceItemID,
+				options.MarketplaceItemItemID,
 			)
 			cobra.CheckErr(err)
 
@@ -65,7 +65,7 @@ This command is in ALPHA state. This means that it can be subject to breaking ch
 		},
 	}
 
-	flagName := options.AddMarketplaceGetItemVersionsFlags(cmd)
+	flagName := options.AddMarketplaceItemItemIDFlag(cmd.Flags())
 	err := cmd.MarkFlagRequired(flagName)
 	if err != nil {
 		// the error is only due to a programming error (missing command flag), hence panic

--- a/internal/cmd/marketplace/list_versions_test.go
+++ b/internal/cmd/marketplace/list_versions_test.go
@@ -105,7 +105,7 @@ func TestGetItemVersions(t *testing.T) {
 				"error": "Not Found",
 			},
 			expected:    nil,
-			expectedErr: ErrItemNotFound,
+			expectedErr: marketplace.ErrItemNotFound,
 		},
 		{
 			testName:   "should return generic error if item is not found",

--- a/internal/resources/marketplace/marketplace.go
+++ b/internal/resources/marketplace/marketplace.go
@@ -21,7 +21,10 @@ import (
 	"github.com/mia-platform/miactl/internal/encoding"
 )
 
-var ErrVersionNameNotAString = errors.New(`the field "version.name" must be a string`)
+var (
+	ErrItemNotFound          = errors.New("item not found")
+	ErrVersionNameNotAString = errors.New(`the field "version.name" must be a string`)
+)
 
 // Item is a Marketplace item
 // we use a map[string]interface{} to represent the item


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
of the work you have done and be sure to link to the relative open issue if is present.

Be aware that all the work you have done should include also the relative tests to assure the
correct behavior and avoid possible regressions in the future.
-->

## What this PR is for?

Modified `miactl marketplace delete` command to accept either the `objectId` or a `itemId`-`version` tuple that identifies the item to be deleted.