### PR TITLE
feat: improve runtime command usage

### DIFF
--- a/docs/30_commands.md
+++ b/docs/30_commands.md
@@ -297,7 +297,11 @@ Available flags for the command:
 
 ### logs
 
-The `runtime logs` subcommand allows you to fetch or stream logs for a given regex of services
+The `runtime logs` subcommand allows you to fetch or stream logs of running pods in the current context using a
+regex query.
+
+You can write any regex compatible with RE2 excluding -C. The regex than will be used to filter down the list of
+pods available in the current context and then the logs of all their containers will be displayed.
 
 Usage:
 

--- a/docs/30_commands.md
+++ b/docs/30_commands.md
@@ -212,10 +212,30 @@ Available flags for the command:
 - `--company-id`, to set the ID of the desired Company
 - `--project-id`, to set the ID of the desired Project
 
+### api-resources
+
+The `runtime api-resources` subcommand allows you to list all the currently supported resources that you can use on
+the `list` command.
+
+Usage:
+
+```sh
+miactl runtime api-resources [flags]
+```
+
+Available flags for the command:
+
+- `--endpoint`, to set the Console endpoint (default is `https://console.cloud.mia-platform.eu`)
+- `--certificate-authority`, to provide the path to a custom CA certificate
+- `--insecure-skip-tls-verify`, to disallow the check the validity of the certificate of the remote endpoint
+- `--context`, to specify a different context from the currently selected one
+
 ### list RESOURCE-TYPE
 
 The `runtime list` subcommand allows you to list all resources of a specific type that are running for the
 environment associated to a given Project.
+
+Use `miactl runtime api-resources` for a complete list of currently supported resources.
 
 Usage:
 

--- a/internal/cmd/logs/logs.go
+++ b/internal/cmd/logs/logs.go
@@ -37,7 +37,17 @@ func Command(o *clioptions.CLIOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logs resource-query",
 		Short: "Show logs related to a runtime resource using a regex query",
-		Long:  "Show logs related to a runtime resource using a regex query.",
+		Long: `Show logs related to a runtime resource using a regex query.
+
+You can write any regex compatible with RE2 excluding -C. The regex than will
+be used to filter down the list of pods available in the current context and
+then the logs of all their containers will be displayed.`,
+
+		Example: `# Get all logs for pods that begin with api-gateway
+miactl runtime logs api-gateway
+
+# Get all logs for pods named exactly job-name
+miactl runtime logs "^job-name$"`,
 
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/cmd/resources/list.go
+++ b/internal/cmd/resources/list.go
@@ -95,8 +95,8 @@ func ListCommand(o *clioptions.CLIOptions) *cobra.Command {
 		Short: "List Mia-Platform Console runtime resources",
 		Long: `List Mia-Platform Console runtime resources.
 
-A project on Mia-Platform Console once deployed can have one or more resource of different kinds associcated with one
-or more of its environments.
+A project on Mia-Platform Console once deployed can have one or more resource
+of different kinds associcated with one or more of its environments.
 
 Use "miactl runtime api-resources" for a complete list of currently supported resources.`,
 		Args: cobra.ExactArgs(1),

--- a/internal/cmd/resources/list.go
+++ b/internal/cmd/resources/list.go
@@ -61,6 +61,14 @@ var resourcesAvailable = []string{
 	ServicesResourceType,
 }
 
+var autocompletableResources = []string{
+	CronJobsResourceType,
+	DeploymentsResourceType,
+	JobsResourceType,
+	PodsResourceType,
+	ServicesResourceType,
+}
+
 func ListCommand(o *clioptions.CLIOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list RESOURCE-TYPE",
@@ -93,7 +101,7 @@ func resourcesCompletions(args []string, toComplete string) []string {
 		return resources
 	}
 
-	for _, resource := range resourcesAvailable {
+	for _, resource := range autocompletableResources {
 		if strings.HasPrefix(resource, toComplete) {
 			resources = append(resources, resource)
 		}

--- a/internal/cmd/resources/list.go
+++ b/internal/cmd/resources/list.go
@@ -69,6 +69,26 @@ var autocompletableResources = []string{
 	ServicesResourceType,
 }
 
+func APIResourcesCommand(_ *clioptions.CLIOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "api-resources",
+		Short: "List Mia-Platform Console supported runtime resources",
+		Long:  "List Mia-Platform Console supported runtime resources.",
+
+		Run: func(cmd *cobra.Command, args []string) {
+			writer := cmd.OutOrStdout()
+			fmt.Fprint(writer, "NAME")
+			fmt.Fprintln(writer)
+			for _, resource := range autocompletableResources {
+				fmt.Fprint(writer, resource)
+				fmt.Fprintln(writer)
+			}
+		},
+	}
+
+	return cmd
+}
+
 func ListCommand(o *clioptions.CLIOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list RESOURCE-TYPE",
@@ -76,7 +96,9 @@ func ListCommand(o *clioptions.CLIOptions) *cobra.Command {
 		Long: `List Mia-Platform Console runtime resources.
 
 A project on Mia-Platform Console once deployed can have one or more resource of different kinds associcated with one
-or more of its environments.`,
+or more of its environments.
+
+Use "miactl runtime api-resources" for a complete list of currently supported resources.`,
 		Args: cobra.ExactArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return resourcesCompletions(args, toComplete), cobra.ShellCompDirectiveNoFileComp
@@ -88,6 +110,11 @@ or more of its environments.`,
 			cobra.CheckErr(err)
 			return printList(client, restConfig.ProjectID, args[0], restConfig.Environment)
 		},
+		Example: `# List all pods in current context
+miactl runtime list pods
+
+# List all service in 'development' environment
+miactl runtime list services --environment development`,
 	}
 
 	o.AddEnvironmentFlags(cmd.Flags())

--- a/internal/cmd/runtime.go
+++ b/internal/cmd/runtime.go
@@ -44,6 +44,7 @@ the resources generated, like Pods, Cronjobs and logs.
 
 	// add sub commands
 	cmd.AddCommand(
+		runtimeresources.APIResourcesCommand(o),
 		runtimeresources.ListCommand(o),
 		runtimeresources.CreateCommand(o),
 		environments.EnvironmentCmd(o),


### PR DESCRIPTION
## What this PR is for?

This PR will both improve the public docs and helper of `runtime logs` and `runtime list` commands and add a brand new command `runtime api-resources` for listing available resource types that can be used with the list command.

This will improve the DX of those commands as highlighted by this community discussion https://github.com/mia-platform/community/discussions/343