### PR TITLE
Add `edit` family of iam commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `company iam add group` command
 - `company iam add group-member` command
 - `company iam edit serviceaccount` command
+- `company iam edit group` command
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `company iam edit user` command
 - `company iam add group` command
 - `company iam add group-member` command
+- `company iam edit serviceaccount` command
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `company iam add user` command
+- `company iam edit user` command
 - `company iam add group` command
 - `company iam add group-member` command
 

--- a/docs/30_commands.md
+++ b/docs/30_commands.md
@@ -285,6 +285,26 @@ Available flags for the command:
 - `--context`, to specify a different context from the currently selected one
 - `--company-id`, to set the ID of the desired Company
 
+#### edit user
+
+The `company iam edit user` subcommand allows you to edit the role associated to a user in your Company.
+
+Usage:
+
+```sh
+miactl company iam edit user [flags]
+```
+
+Available flags for the command:
+
+- `--endpoint`, to set the Console endpoint (default is `https://console.cloud.mia-platform.eu`)
+- `--certificate-authority`, to provide the path to a custom CA certificate
+- `--insecure-skip-tls-verify`, to disallow the check the validity of the certificate of the remote endpoint
+- `--context`, to specify a different context from the currently selected one
+- `--company-id`, to set the ID of the desired Company
+- `--user-id`, the user-id of the user to edit
+- `--role`, the new Company role of the user
+
 ## project
 
 This command allows you to manage `miactl` Projects.

--- a/docs/30_commands.md
+++ b/docs/30_commands.md
@@ -326,6 +326,26 @@ Available flags for the command:
 - `--service-account-id`, the id of the service account to edit
 - `--role`, the new Company role of the service account
 
+#### edit group
+
+The `company iam edit group` subcommand allows you to edit the role associated to a group in your Company.
+
+Usage:
+
+```sh
+miactl company iam edit group [flags]
+```
+
+Available flags for the command:
+
+- `--endpoint`, to set the Console endpoint (default is `https://console.cloud.mia-platform.eu`)
+- `--certificate-authority`, to provide the path to a custom CA certificate
+- `--insecure-skip-tls-verify`, to disallow the check the validity of the certificate of the remote endpoint
+- `--context`, to specify a different context from the currently selected one
+- `--company-id`, to set the ID of the desired Company
+- `--group-id`, the id of the group to edit
+- `--role`, the new Company role of the group
+
 ## project
 
 This command allows you to manage `miactl` Projects.

--- a/docs/30_commands.md
+++ b/docs/30_commands.md
@@ -302,8 +302,29 @@ Available flags for the command:
 - `--insecure-skip-tls-verify`, to disallow the check the validity of the certificate of the remote endpoint
 - `--context`, to specify a different context from the currently selected one
 - `--company-id`, to set the ID of the desired Company
-- `--user-id`, the user-id of the user to edit
+- `--user-id`, the id of the user to edit
 - `--role`, the new Company role of the user
+
+#### edit serviceaccount
+
+The `company iam edit serviceaccount` subcommand allows you to edit the role associated to a service account in
+your Company.
+
+Usage:
+
+```sh
+miactl company iam edit serviceaccount [flags]
+```
+
+Available flags for the command:
+
+- `--endpoint`, to set the Console endpoint (default is `https://console.cloud.mia-platform.eu`)
+- `--certificate-authority`, to provide the path to a custom CA certificate
+- `--insecure-skip-tls-verify`, to disallow the check the validity of the certificate of the remote endpoint
+- `--context`, to specify a different context from the currently selected one
+- `--company-id`, to set the ID of the desired Company
+- `--service-account-id`, the id of the service account to edit
+- `--role`, the new Company role of the service account
 
 ## project
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -29,6 +29,7 @@ type Interface interface {
 	Delete() *Request
 	Get() *Request
 	Post() *Request
+	Patch() *Request
 	HTTPClient() *http.Client
 }
 
@@ -76,6 +77,10 @@ func (c *APIClient) Post() *Request {
 // Delete return a new Request object for a DELETE http request
 func (c *APIClient) Delete() *Request {
 	return NewRequest(c).SetVerb(http.MethodDelete)
+}
+
+func (c *APIClient) Patch() *Request {
+	return NewRequest(c).SetVerb(http.MethodPatch)
 }
 
 func (c *APIClient) HTTPClient() *http.Client {

--- a/internal/clioptions/clioptions.go
+++ b/internal/clioptions/clioptions.go
@@ -149,7 +149,7 @@ func (o *CLIOptions) AddJWTServiceAccountFlags(flags *pflag.FlagSet) {
 }
 
 func (o *CLIOptions) AddEditServiceAccountFlags(flags *pflag.FlagSet) {
-	flags.StringVarP(&o.IAMRole, "role", "r", "", "the new company role for the user")
+	flags.StringVarP(&o.IAMRole, "role", "r", "", "the new company role for the service account")
 	flags.StringVarP(&o.ServiceAccountID, "service-account-id", "", "", "the service account id to edit")
 }
 
@@ -170,6 +170,11 @@ func (o *CLIOptions) CreateNewGroupFlags(flags *pflag.FlagSet) {
 func (o *CLIOptions) AddMemberToGroupFlags(flags *pflag.FlagSet) {
 	flags.StringSliceVarP(&o.UserEmails, "user-email", "", []string{}, "the list of user email to add to the group")
 	flags.StringVarP(&o.GroupID, "group-id", "", "", "the group id where to add the users")
+}
+
+func (o *CLIOptions) AddEditGroupFlags(flags *pflag.FlagSet) {
+	flags.StringVarP(&o.IAMRole, "role", "r", "", "the new company role for the group")
+	flags.StringVarP(&o.GroupID, "group-id", "", "", "the group id to edit")
 }
 
 func (o *CLIOptions) AddMarketplaceApplyFlags(cmd *cobra.Command) {

--- a/internal/clioptions/clioptions.go
+++ b/internal/clioptions/clioptions.go
@@ -54,6 +54,8 @@ type CLIOptions struct {
 	UserEmails []string
 	GroupID    string
 
+	ServiceAccountID string
+
 	BasicClientID     string
 	BasicClientSecret string
 	JWTJsonPath       string
@@ -144,6 +146,11 @@ func (o *CLIOptions) AddServiceAccountFlags(flags *pflag.FlagSet) {
 func (o *CLIOptions) AddJWTServiceAccountFlags(flags *pflag.FlagSet) {
 	o.AddServiceAccountFlags(flags)
 	flags.StringVarP(&o.OutputPath, "output", "o", "", "write the service account configuration as json to a file")
+}
+
+func (o *CLIOptions) AddEditServiceAccountFlags(flags *pflag.FlagSet) {
+	flags.StringVarP(&o.IAMRole, "role", "r", "", "the new company role for the user")
+	flags.StringVarP(&o.ServiceAccountID, "service-account-id", "", "", "the service account id to edit")
 }
 
 func (o *CLIOptions) AddNewUserFlags(flags *pflag.FlagSet) {

--- a/internal/clioptions/clioptions.go
+++ b/internal/clioptions/clioptions.go
@@ -49,6 +49,7 @@ type CLIOptions struct {
 	IAMRole string
 
 	UserEmail string
+	UserID    string
 
 	UserEmails []string
 	GroupID    string
@@ -148,6 +149,11 @@ func (o *CLIOptions) AddJWTServiceAccountFlags(flags *pflag.FlagSet) {
 func (o *CLIOptions) AddNewUserFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.IAMRole, "role", "r", "", "the company role of the user")
 	flags.StringVarP(&o.UserEmail, "email", "", "", "the email of the user to add")
+}
+
+func (o *CLIOptions) AddEditUserFlags(flags *pflag.FlagSet) {
+	flags.StringVarP(&o.IAMRole, "role", "r", "", "the new company role for the user")
+	flags.StringVarP(&o.UserID, "user-id", "", "", "the user id to edit")
 }
 
 func (o *CLIOptions) CreateNewGroupFlags(flags *pflag.FlagSet) {

--- a/internal/cmd/company/iam/edit.go
+++ b/internal/cmd/company/iam/edit.go
@@ -13,32 +13,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package company
+package iam
 
 import (
 	"github.com/mia-platform/miactl/internal/clioptions"
-	"github.com/mia-platform/miactl/internal/cmd/company/iam"
+	"github.com/mia-platform/miactl/internal/cmd/company/iam/user"
 	"github.com/spf13/cobra"
 )
 
-func IAMCmd(o *clioptions.CLIOptions) *cobra.Command {
+func EditCmd(options *clioptions.CLIOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "iam",
-		Short: "Manage Mia-Platform IAM for a company",
-		Long: `A Company Owner user can manager the access to the company directly to a user,
-via a group or through service accounts.`,
+		Use:   "edit",
+		Short: "Edit an IAM entity in a company",
+		Long:  "Edit an IAM entity in a company",
 	}
 
-	// add cmd flags
-	flags := cmd.PersistentFlags()
-	o.AddConnectionFlags(flags)
-	o.AddContextFlags(flags)
-	o.AddCompanyFlags(flags)
-
 	cmd.AddCommand(
-		iam.ListCmd(o),
-		iam.AddCmd(o),
-		iam.EditCmd(o),
+		user.EditCmd(options),
 	)
 
 	return cmd

--- a/internal/cmd/company/iam/edit.go
+++ b/internal/cmd/company/iam/edit.go
@@ -17,6 +17,7 @@ package iam
 
 import (
 	"github.com/mia-platform/miactl/internal/clioptions"
+	"github.com/mia-platform/miactl/internal/cmd/company/iam/serviceaccount"
 	"github.com/mia-platform/miactl/internal/cmd/company/iam/user"
 	"github.com/spf13/cobra"
 )
@@ -30,6 +31,7 @@ func EditCmd(options *clioptions.CLIOptions) *cobra.Command {
 
 	cmd.AddCommand(
 		user.EditCmd(options),
+		serviceaccount.EditCmd(options),
 	)
 
 	return cmd

--- a/internal/cmd/company/iam/edit.go
+++ b/internal/cmd/company/iam/edit.go
@@ -17,6 +17,7 @@ package iam
 
 import (
 	"github.com/mia-platform/miactl/internal/clioptions"
+	"github.com/mia-platform/miactl/internal/cmd/company/iam/group"
 	"github.com/mia-platform/miactl/internal/cmd/company/iam/serviceaccount"
 	"github.com/mia-platform/miactl/internal/cmd/company/iam/user"
 	"github.com/spf13/cobra"
@@ -32,6 +33,7 @@ func EditCmd(options *clioptions.CLIOptions) *cobra.Command {
 	cmd.AddCommand(
 		user.EditCmd(options),
 		serviceaccount.EditCmd(options),
+		group.EditCmd(options),
 	)
 
 	return cmd

--- a/internal/cmd/company/iam/group/create.go
+++ b/internal/cmd/company/iam/group/create.go
@@ -42,22 +42,13 @@ func AddCmd(options *clioptions.CLIOptions) *cobra.Command {
 			client, err := client.APIClientForConfig(restConfig)
 			cobra.CheckErr(err)
 
-			err = createNewGroup(cmd.Context(), client, restConfig.CompanyID, args[0], resources.ServiceAccountRole(options.IAMRole))
+			err = createNewGroup(cmd.Context(), client, restConfig.CompanyID, args[0], resources.IAMRole(options.IAMRole))
 			cobra.CheckErr(err)
 		},
 	}
 
 	options.CreateNewGroupFlags(cmd.Flags())
-	err := cmd.RegisterFlagCompletionFunc("role", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{
-			resources.ServiceAccountRoleGuest.String(),
-			resources.ServiceAccountRoleReporter.String(),
-			resources.ServiceAccountRoleDeveloper.String(),
-			resources.ServiceAccountRoleMaintainer.String(),
-			resources.ServiceAccountRoleProjectAdmin.String(),
-			resources.ServiceAccountRoleCompanyOwner.String(),
-		}, cobra.ShellCompDirectiveDefault
-	})
+	err := cmd.RegisterFlagCompletionFunc("role", resources.IAMRoleCompletion)
 
 	if err != nil {
 		// we panic here because if we reach here, something nasty is happening in flag autocomplete registration
@@ -67,8 +58,8 @@ func AddCmd(options *clioptions.CLIOptions) *cobra.Command {
 	return cmd
 }
 
-func createNewGroup(ctx context.Context, client *client.APIClient, companyID, groupName string, role resources.ServiceAccountRole) error {
-	if !resources.IsValidServiceAccountRole(role) {
+func createNewGroup(ctx context.Context, client *client.APIClient, companyID, groupName string, role resources.IAMRole) error {
+	if !resources.IsValidIAMRole(role) {
 		return fmt.Errorf("invalid service account role %s", role)
 	}
 

--- a/internal/cmd/company/iam/group/create_test.go
+++ b/internal/cmd/company/iam/group/create_test.go
@@ -32,41 +32,41 @@ func TestCreateGroup(t *testing.T) {
 	testCases := map[string]struct {
 		server    *httptest.Server
 		companyID string
-		role      resources.ServiceAccountRole
+		role      resources.IAMRole
 		groupName string
 		expectErr bool
 	}{
 		"create group": {
 			server:    addUserTestServer(t),
 			companyID: "success",
-			role:      resources.ServiceAccountRoleGuest,
+			role:      resources.IAMRoleGuest,
 			groupName: "group-name",
 		},
 		"missing company": {
 			server:    addUserTestServer(t),
 			companyID: "",
-			role:      resources.ServiceAccountRoleGuest,
+			role:      resources.IAMRoleGuest,
 			groupName: "group-name",
 			expectErr: true,
 		},
 		"missing group name": {
 			server:    addUserTestServer(t),
 			companyID: "success",
-			role:      resources.ServiceAccountRoleGuest,
+			role:      resources.IAMRoleGuest,
 			groupName: "",
 			expectErr: true,
 		},
 		"wrong role": {
 			server:    addUserTestServer(t),
 			companyID: "succes",
-			role:      resources.ServiceAccountRole("example"),
+			role:      resources.IAMRole("example"),
 			groupName: "group-name",
 			expectErr: true,
 		},
 		"error from backend": {
 			server:    addUserTestServer(t),
 			companyID: "fail",
-			role:      resources.ServiceAccountRoleCompanyOwner,
+			role:      resources.IAMRoleCompanyOwner,
 			groupName: "group-name",
 			expectErr: true,
 		},

--- a/internal/cmd/company/iam/group/edit.go
+++ b/internal/cmd/company/iam/group/edit.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package serviceaccount
+package group
 
 import (
 	"context"
@@ -26,14 +26,14 @@ import (
 )
 
 const (
-	editServiceAccountRoleTemplate = "/api/companies/%s/service-accounts/%s"
+	editGroupRoleTemplate = "/api/companies/%s/groups/%s"
 )
 
 func EditCmd(options *clioptions.CLIOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "serviceaccount",
-		Short: "Edit a service account in a company",
-		Long:  "Edit a service account in a company",
+		Use:   "group",
+		Short: "Edit a group in a company",
+		Long:  "Edit a group in a company",
 
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -42,12 +42,12 @@ func EditCmd(options *clioptions.CLIOptions) *cobra.Command {
 			client, err := client.APIClientForConfig(restConfig)
 			cobra.CheckErr(err)
 
-			err = editCompanyServiceAccount(cmd.Context(), client, restConfig.CompanyID, options.ServiceAccountID, resources.IAMRole(options.IAMRole))
+			err = editCompanyGroup(cmd.Context(), client, restConfig.CompanyID, options.GroupID, resources.IAMRole(options.IAMRole))
 			cobra.CheckErr(err)
 		},
 	}
 
-	options.AddEditServiceAccountFlags(cmd.Flags())
+	options.AddEditGroupFlags(cmd.Flags())
 	err := cmd.RegisterFlagCompletionFunc("role", resources.IAMRoleCompletion)
 
 	if err != nil {
@@ -58,7 +58,7 @@ func EditCmd(options *clioptions.CLIOptions) *cobra.Command {
 	return cmd
 }
 
-func editCompanyServiceAccount(ctx context.Context, client *client.APIClient, companyID, serviceAccountID string, role resources.IAMRole) error {
+func editCompanyGroup(ctx context.Context, client *client.APIClient, companyID, groupID string, role resources.IAMRole) error {
 	if !resources.IsValidIAMRole(role) {
 		return fmt.Errorf("invalid service account role %s", role)
 	}
@@ -67,8 +67,8 @@ func editCompanyServiceAccount(ctx context.Context, client *client.APIClient, co
 		return fmt.Errorf("company id is required, please set it via flag or context")
 	}
 
-	if len(serviceAccountID) == 0 {
-		return fmt.Errorf("the service account id is required")
+	if len(groupID) == 0 {
+		return fmt.Errorf("the group id is required")
 	}
 
 	payload := resources.EditIAMRole{
@@ -82,7 +82,7 @@ func editCompanyServiceAccount(ctx context.Context, client *client.APIClient, co
 
 	resp, err := client.
 		Patch().
-		APIPath(fmt.Sprintf(editServiceAccountRoleTemplate, companyID, serviceAccountID)).
+		APIPath(fmt.Sprintf(editGroupRoleTemplate, companyID, groupID)).
 		Body(body).
 		Do(ctx)
 
@@ -94,6 +94,6 @@ func editCompanyServiceAccount(ctx context.Context, client *client.APIClient, co
 		return err
 	}
 
-	fmt.Printf("service account %s role successfully updated\n", serviceAccountID)
+	fmt.Printf("group %s role successfully updated\n", groupID)
 	return nil
 }

--- a/internal/cmd/company/iam/group/edit_test.go
+++ b/internal/cmd/company/iam/group/edit_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package user
+package group
 
 import (
 	"context"
@@ -28,46 +28,46 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEditUser(t *testing.T) {
+func TestEditGroup(t *testing.T) {
 	testCases := map[string]struct {
 		server    *httptest.Server
 		companyID string
 		role      resources.IAMRole
-		userID    string
+		groupID   string
 		expectErr bool
 	}{
-		"edit user": {
-			server:    editUserTestServer(t),
+		"edit group": {
+			server:    editGroupTestServer(t),
 			companyID: "success",
 			role:      resources.IAMRoleGuest,
-			userID:    "000000000000000000000001",
+			groupID:   "000000000000000000000001",
 		},
 		"missing company": {
-			server:    editUserTestServer(t),
+			server:    editGroupTestServer(t),
 			companyID: "",
 			role:      resources.IAMRoleGuest,
-			userID:    "000000000000000000000001",
+			groupID:   "000000000000000000000001",
 			expectErr: true,
 		},
-		"missing user id": {
-			server:    editUserTestServer(t),
+		"missing group id": {
+			server:    editGroupTestServer(t),
 			companyID: "success",
 			role:      resources.IAMRoleGuest,
-			userID:    "",
+			groupID:   "",
 			expectErr: true,
 		},
 		"wrong role": {
-			server:    editUserTestServer(t),
+			server:    editGroupTestServer(t),
 			companyID: "",
 			role:      resources.IAMRole("example"),
-			userID:    "000000000000000000000001",
+			groupID:   "000000000000000000000001",
 			expectErr: true,
 		},
 		"error from backend": {
-			server:    editUserTestServer(t),
+			server:    editGroupTestServer(t),
 			companyID: "fail",
 			role:      resources.IAMRoleCompanyOwner,
-			userID:    "000000000000000000000001",
+			groupID:   "000000000000000000000001",
 			expectErr: true,
 		},
 	}
@@ -80,11 +80,11 @@ func TestEditUser(t *testing.T) {
 				Host: server.URL,
 			})
 			require.NoError(t, err)
-			err = editCompanyUser(
+			err = editCompanyGroup(
 				context.TODO(),
 				client,
 				testCase.companyID,
-				testCase.userID,
+				testCase.groupID,
 				testCase.role,
 			)
 
@@ -98,14 +98,14 @@ func TestEditUser(t *testing.T) {
 	}
 }
 
-func editUserTestServer(t *testing.T) *httptest.Server {
+func editGroupTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf(editUserRoleTemplate, "success", "000000000000000000000001"):
+		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf(editGroupRoleTemplate, "success", "000000000000000000000001"):
 			w.WriteHeader(http.StatusOK)
-		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf(editUserRoleTemplate, "fail", "000000000000000000000001"):
+		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf(editGroupRoleTemplate, "fail", "000000000000000000000001"):
 			w.WriteHeader(http.StatusBadRequest)
 		default:
 			require.Fail(t, "request not implemented", "request received for %s with %s method", r.URL, r.Method)

--- a/internal/cmd/company/iam/serviceaccount/basic/basic.go
+++ b/internal/cmd/company/iam/serviceaccount/basic/basic.go
@@ -45,7 +45,7 @@ service account is created on the company.`,
 			cobra.CheckErr(err)
 			client, err := client.APIClientForConfig(restConfig)
 			cobra.CheckErr(err)
-			credentials, err := createBasicServiceAccount(cmd.Context(), client, serviceAccountName, restConfig.CompanyID, resources.ServiceAccountRole(options.IAMRole))
+			credentials, err := createBasicServiceAccount(cmd.Context(), client, serviceAccountName, restConfig.CompanyID, resources.IAMRole(options.IAMRole))
 			if err != nil {
 				return err
 			}
@@ -59,16 +59,7 @@ service account is created on the company.`,
 
 	// add cmd flags
 	options.AddServiceAccountFlags(cmd.Flags())
-	err := cmd.RegisterFlagCompletionFunc("role", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{
-			resources.ServiceAccountRoleGuest.String(),
-			resources.ServiceAccountRoleReporter.String(),
-			resources.ServiceAccountRoleDeveloper.String(),
-			resources.ServiceAccountRoleMaintainer.String(),
-			resources.ServiceAccountRoleProjectAdmin.String(),
-			resources.ServiceAccountRoleCompanyOwner.String(),
-		}, cobra.ShellCompDirectiveDefault
-	})
+	err := cmd.RegisterFlagCompletionFunc("role", resources.IAMRoleCompletion)
 
 	if err != nil {
 		// we panic here because if we reach here, something nasty is happening in flag autocomplete registration
@@ -78,8 +69,8 @@ service account is created on the company.`,
 	return cmd
 }
 
-func createBasicServiceAccount(ctx context.Context, client *client.APIClient, name, companyID string, role resources.ServiceAccountRole) ([]string, error) {
-	if !resources.IsValidServiceAccountRole(role) {
+func createBasicServiceAccount(ctx context.Context, client *client.APIClient, name, companyID string, role resources.IAMRole) ([]string, error) {
+	if !resources.IsValidIAMRole(role) {
 		return nil, fmt.Errorf("invalid service account role %s", role)
 	}
 

--- a/internal/cmd/company/iam/serviceaccount/basic/basic_test.go
+++ b/internal/cmd/company/iam/serviceaccount/basic/basic_test.go
@@ -39,7 +39,7 @@ func TestCreateBasicServiceAccount(t *testing.T) {
 		server              *httptest.Server
 		serviceAccountName  string
 		companyID           string
-		role                resources.ServiceAccountRole
+		role                resources.IAMRole
 		expectedCredentials []string
 		expectErr           bool
 	}{
@@ -47,7 +47,7 @@ func TestCreateBasicServiceAccount(t *testing.T) {
 			server:             testServer(t),
 			serviceAccountName: "new-sa",
 			companyID:          "company",
-			role:               resources.ServiceAccountRoleReporter,
+			role:               resources.IAMRoleReporter,
 			expectedCredentials: []string{
 				"client-id",
 				"client-secret",
@@ -57,13 +57,13 @@ func TestCreateBasicServiceAccount(t *testing.T) {
 			server:              testServer(t),
 			serviceAccountName:  "new-sa",
 			companyID:           "error",
-			role:                resources.ServiceAccountRoleReporter,
+			role:                resources.IAMRoleReporter,
 			expectErr:           true,
 			expectedCredentials: nil,
 		},
 		"wrong role": {
 			server:    testServer(t),
-			role:      resources.ServiceAccountRole("wrong"),
+			role:      resources.IAMRole("wrong"),
 			expectErr: true,
 		},
 	}

--- a/internal/cmd/company/iam/serviceaccount/edit.go
+++ b/internal/cmd/company/iam/serviceaccount/edit.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package user
+package serviceaccount
 
 import (
 	"context"
@@ -26,14 +26,14 @@ import (
 )
 
 const (
-	editUserRoleTemplate = "/api/companies/%s/users/%s"
+	editServiceAccountRoleTemplate = "/api/companies/%s/service-accounts/%s"
 )
 
 func EditCmd(options *clioptions.CLIOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "user",
-		Short: "Edit a user in a company",
-		Long:  "Edit a user in a company",
+		Use:   "serviceaccount",
+		Short: "Edit a service account in a company",
+		Long:  "Edit a service account in a company",
 
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -42,12 +42,12 @@ func EditCmd(options *clioptions.CLIOptions) *cobra.Command {
 			client, err := client.APIClientForConfig(restConfig)
 			cobra.CheckErr(err)
 
-			err = editCompanyUser(cmd.Context(), client, restConfig.CompanyID, options.UserID, resources.ServiceAccountRole(options.IAMRole))
+			err = editCompanyServiceAccount(cmd.Context(), client, restConfig.CompanyID, options.ServiceAccountID, resources.ServiceAccountRole(options.IAMRole))
 			cobra.CheckErr(err)
 		},
 	}
 
-	options.AddEditUserFlags(cmd.Flags())
+	options.AddEditServiceAccountFlags(cmd.Flags())
 	err := cmd.RegisterFlagCompletionFunc("role", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{
 			resources.ServiceAccountRoleGuest.String(),
@@ -67,7 +67,7 @@ func EditCmd(options *clioptions.CLIOptions) *cobra.Command {
 	return cmd
 }
 
-func editCompanyUser(ctx context.Context, client *client.APIClient, companyID, userID string, role resources.ServiceAccountRole) error {
+func editCompanyServiceAccount(ctx context.Context, client *client.APIClient, companyID, serviceAccountID string, role resources.ServiceAccountRole) error {
 	if !resources.IsValidServiceAccountRole(role) {
 		return fmt.Errorf("invalid service account role %s", role)
 	}
@@ -76,7 +76,7 @@ func editCompanyUser(ctx context.Context, client *client.APIClient, companyID, u
 		return fmt.Errorf("company id is required, please set it via flag or context")
 	}
 
-	if len(userID) == 0 {
+	if len(serviceAccountID) == 0 {
 		return fmt.Errorf("the user id is required")
 	}
 
@@ -91,7 +91,7 @@ func editCompanyUser(ctx context.Context, client *client.APIClient, companyID, u
 
 	resp, err := client.
 		Patch().
-		APIPath(fmt.Sprintf(editUserRoleTemplate, companyID, userID)).
+		APIPath(fmt.Sprintf(editServiceAccountRoleTemplate, companyID, serviceAccountID)).
 		Body(body).
 		Do(ctx)
 
@@ -103,6 +103,6 @@ func editCompanyUser(ctx context.Context, client *client.APIClient, companyID, u
 		return err
 	}
 
-	fmt.Printf("user %s role successfully updated\n", userID)
+	fmt.Printf("service account %s role successfully updated\n", serviceAccountID)
 	return nil
 }

--- a/internal/cmd/company/iam/serviceaccount/edit_test.go
+++ b/internal/cmd/company/iam/serviceaccount/edit_test.go
@@ -32,41 +32,41 @@ func TestEditServiceAccount(t *testing.T) {
 	testCases := map[string]struct {
 		server           *httptest.Server
 		companyID        string
-		role             resources.ServiceAccountRole
+		role             resources.IAMRole
 		serviceAccountID string
 		expectErr        bool
 	}{
 		"edit service account": {
 			server:           editServiceAccountTestServer(t),
 			companyID:        "success",
-			role:             resources.ServiceAccountRoleGuest,
+			role:             resources.IAMRoleGuest,
 			serviceAccountID: "000000000000000000000001",
 		},
 		"missing company": {
 			server:           editServiceAccountTestServer(t),
 			companyID:        "",
-			role:             resources.ServiceAccountRoleGuest,
+			role:             resources.IAMRoleGuest,
 			serviceAccountID: "000000000000000000000001",
 			expectErr:        true,
 		},
 		"missing service account id": {
 			server:           editServiceAccountTestServer(t),
 			companyID:        "success",
-			role:             resources.ServiceAccountRoleGuest,
+			role:             resources.IAMRoleGuest,
 			serviceAccountID: "",
 			expectErr:        true,
 		},
 		"wrong role": {
 			server:           editServiceAccountTestServer(t),
 			companyID:        "",
-			role:             resources.ServiceAccountRole("example"),
+			role:             resources.IAMRole("example"),
 			serviceAccountID: "000000000000000000000001",
 			expectErr:        true,
 		},
 		"error from backend": {
 			server:           editServiceAccountTestServer(t),
 			companyID:        "fail",
-			role:             resources.ServiceAccountRoleCompanyOwner,
+			role:             resources.IAMRoleCompanyOwner,
 			serviceAccountID: "000000000000000000000001",
 			expectErr:        true,
 		},

--- a/internal/cmd/company/iam/serviceaccount/edit_test.go
+++ b/internal/cmd/company/iam/serviceaccount/edit_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package user
+package serviceaccount
 
 import (
 	"context"
@@ -28,47 +28,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEditUser(t *testing.T) {
+func TestEditServiceAccount(t *testing.T) {
 	testCases := map[string]struct {
-		server    *httptest.Server
-		companyID string
-		role      resources.ServiceAccountRole
-		userID    string
-		expectErr bool
+		server           *httptest.Server
+		companyID        string
+		role             resources.ServiceAccountRole
+		serviceAccountID string
+		expectErr        bool
 	}{
-		"edit user": {
-			server:    editUserTestServer(t),
-			companyID: "success",
-			role:      resources.ServiceAccountRoleGuest,
-			userID:    "000000000000000000000001",
+		"edit service account": {
+			server:           editServiceAccountTestServer(t),
+			companyID:        "success",
+			role:             resources.ServiceAccountRoleGuest,
+			serviceAccountID: "000000000000000000000001",
 		},
 		"missing company": {
-			server:    editUserTestServer(t),
-			companyID: "",
-			role:      resources.ServiceAccountRoleGuest,
-			userID:    "000000000000000000000001",
-			expectErr: true,
+			server:           editServiceAccountTestServer(t),
+			companyID:        "",
+			role:             resources.ServiceAccountRoleGuest,
+			serviceAccountID: "000000000000000000000001",
+			expectErr:        true,
 		},
-		"missing user id": {
-			server:    editUserTestServer(t),
-			companyID: "success",
-			role:      resources.ServiceAccountRoleGuest,
-			userID:    "",
-			expectErr: true,
+		"missing service account id": {
+			server:           editServiceAccountTestServer(t),
+			companyID:        "success",
+			role:             resources.ServiceAccountRoleGuest,
+			serviceAccountID: "",
+			expectErr:        true,
 		},
 		"wrong role": {
-			server:    editUserTestServer(t),
-			companyID: "",
-			role:      resources.ServiceAccountRole("example"),
-			userID:    "000000000000000000000001",
-			expectErr: true,
+			server:           editServiceAccountTestServer(t),
+			companyID:        "",
+			role:             resources.ServiceAccountRole("example"),
+			serviceAccountID: "000000000000000000000001",
+			expectErr:        true,
 		},
 		"error from backend": {
-			server:    editUserTestServer(t),
-			companyID: "fail",
-			role:      resources.ServiceAccountRoleCompanyOwner,
-			userID:    "000000000000000000000001",
-			expectErr: true,
+			server:           editServiceAccountTestServer(t),
+			companyID:        "fail",
+			role:             resources.ServiceAccountRoleCompanyOwner,
+			serviceAccountID: "000000000000000000000001",
+			expectErr:        true,
 		},
 	}
 
@@ -80,11 +80,11 @@ func TestEditUser(t *testing.T) {
 				Host: server.URL,
 			})
 			require.NoError(t, err)
-			err = editCompanyUser(
+			err = editCompanyServiceAccount(
 				context.TODO(),
 				client,
 				testCase.companyID,
-				testCase.userID,
+				testCase.serviceAccountID,
 				testCase.role,
 			)
 
@@ -98,14 +98,14 @@ func TestEditUser(t *testing.T) {
 	}
 }
 
-func editUserTestServer(t *testing.T) *httptest.Server {
+func editServiceAccountTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf(editUserRoleTemplate, "success", "000000000000000000000001"):
+		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf(editServiceAccountRoleTemplate, "success", "000000000000000000000001"):
 			w.WriteHeader(http.StatusOK)
-		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf(editUserRoleTemplate, "fail", "000000000000000000000001"):
+		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf(editServiceAccountRoleTemplate, "fail", "000000000000000000000001"):
 			w.WriteHeader(http.StatusBadRequest)
 		default:
 			require.Fail(t, "request not implemented", "request received for %s with %s method", r.URL, r.Method)

--- a/internal/cmd/company/iam/serviceaccount/jwt/jwt.go
+++ b/internal/cmd/company/iam/serviceaccount/jwt/jwt.go
@@ -57,7 +57,7 @@ service account is created on the company.`,
 			cobra.CheckErr(err)
 			client, err := client.APIClientForConfig(restConfig)
 			cobra.CheckErr(err)
-			credentials, err := createJWTServiceAccount(cmd.Context(), client, serviceAccountName, restConfig.CompanyID, resources.ServiceAccountRole(options.IAMRole))
+			credentials, err := createJWTServiceAccount(cmd.Context(), client, serviceAccountName, restConfig.CompanyID, resources.IAMRole(options.IAMRole))
 			if err != nil {
 				return err
 			}
@@ -68,16 +68,7 @@ service account is created on the company.`,
 
 	// add cmd flags
 	options.AddJWTServiceAccountFlags(cmd.Flags())
-	err := cmd.RegisterFlagCompletionFunc("role", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{
-			resources.ServiceAccountRoleGuest.String(),
-			resources.ServiceAccountRoleReporter.String(),
-			resources.ServiceAccountRoleDeveloper.String(),
-			resources.ServiceAccountRoleMaintainer.String(),
-			resources.ServiceAccountRoleProjectAdmin.String(),
-			resources.ServiceAccountRoleCompanyOwner.String(),
-		}, cobra.ShellCompDirectiveDefault
-	})
+	err := cmd.RegisterFlagCompletionFunc("role", resources.IAMRoleCompletion)
 
 	if err != nil {
 		// we panic here because if we reach here, something nasty is happenign in flag autocomplete registration
@@ -93,8 +84,8 @@ service account is created on the company.`,
 	return cmd
 }
 
-func createJWTServiceAccount(ctx context.Context, client *client.APIClient, name, companyID string, role resources.ServiceAccountRole) (*resources.JWTServiceAccountJSON, error) {
-	if !resources.IsValidServiceAccountRole(role) {
+func createJWTServiceAccount(ctx context.Context, client *client.APIClient, name, companyID string, role resources.IAMRole) (*resources.JWTServiceAccountJSON, error) {
+	if !resources.IsValidIAMRole(role) {
 		return nil, fmt.Errorf("invalid service account role %s", role)
 	}
 
@@ -182,7 +173,7 @@ func generateRSAKey() (*rsa.PrivateKey, error) {
 	return rsa.GenerateKey(rand.Reader, rsaKeyBytes)
 }
 
-func requestFromKey(name string, role resources.ServiceAccountRole, key *rsa.PrivateKey) *resources.ServiceAccountRequest {
+func requestFromKey(name string, role resources.IAMRole, key *rsa.PrivateKey) *resources.ServiceAccountRequest {
 	encoder := base64.RawURLEncoding
 	modulus, exponent := rsaPublicKeyToBytes(&key.PublicKey)
 

--- a/internal/cmd/company/iam/serviceaccount/jwt/jwt_test.go
+++ b/internal/cmd/company/iam/serviceaccount/jwt/jwt_test.go
@@ -34,9 +34,9 @@ func TestRequestFromKey(t *testing.T) {
 	key, err := generateRSAKey()
 	assert.NoError(t, err)
 
-	payload := requestFromKey("testName", resources.ServiceAccountRoleCompanyOwner, key)
+	payload := requestFromKey("testName", resources.IAMRoleCompanyOwner, key)
 	assert.Equal(t, "testName", payload.Name)
-	assert.Equal(t, resources.ServiceAccountRoleCompanyOwner, payload.Role)
+	assert.Equal(t, resources.IAMRoleCompanyOwner, payload.Role)
 	assert.Equal(t, "sig", payload.PublicKey.Use)
 	assert.Equal(t, "RSA", payload.PublicKey.Type)
 	assert.Equal(t, "RSA256", payload.PublicKey.Algorithm)
@@ -48,24 +48,24 @@ func TestCreateServiceAccount(t *testing.T) {
 	testCases := map[string]struct {
 		server    *httptest.Server
 		companyID string
-		role      resources.ServiceAccountRole
+		role      resources.IAMRole
 		expectErr bool
 	}{
 		"create successul": {
 			server:    testServer(t),
 			companyID: "company",
-			role:      resources.ServiceAccountRoleGuest,
+			role:      resources.IAMRoleGuest,
 		},
 		"wrong role": {
 			server:    testServer(t),
 			companyID: "unused",
-			role:      resources.ServiceAccountRole("wrong"),
+			role:      resources.IAMRole("wrong"),
 			expectErr: true,
 		},
 		"remote error": {
 			server:    testServer(t),
 			companyID: "error",
-			role:      resources.ServiceAccountRoleGuest,
+			role:      resources.IAMRoleGuest,
 			expectErr: true,
 		},
 	}

--- a/internal/cmd/company/iam/user/create.go
+++ b/internal/cmd/company/iam/user/create.go
@@ -42,22 +42,13 @@ func AddCmd(options *clioptions.CLIOptions) *cobra.Command {
 			client, err := client.APIClientForConfig(restConfig)
 			cobra.CheckErr(err)
 
-			err = addUserToCompany(cmd.Context(), client, restConfig.CompanyID, options.UserEmail, resources.ServiceAccountRole(options.IAMRole))
+			err = addUserToCompany(cmd.Context(), client, restConfig.CompanyID, options.UserEmail, resources.IAMRole(options.IAMRole))
 			cobra.CheckErr(err)
 		},
 	}
 
 	options.AddNewUserFlags(cmd.Flags())
-	err := cmd.RegisterFlagCompletionFunc("role", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{
-			resources.ServiceAccountRoleGuest.String(),
-			resources.ServiceAccountRoleReporter.String(),
-			resources.ServiceAccountRoleDeveloper.String(),
-			resources.ServiceAccountRoleMaintainer.String(),
-			resources.ServiceAccountRoleProjectAdmin.String(),
-			resources.ServiceAccountRoleCompanyOwner.String(),
-		}, cobra.ShellCompDirectiveDefault
-	})
+	err := cmd.RegisterFlagCompletionFunc("role", resources.IAMRoleCompletion)
 
 	if err != nil {
 		// we panic here because if we reach here, something nasty is happening in flag autocomplete registration
@@ -67,8 +58,8 @@ func AddCmd(options *clioptions.CLIOptions) *cobra.Command {
 	return cmd
 }
 
-func addUserToCompany(ctx context.Context, client *client.APIClient, companyID, userEmail string, role resources.ServiceAccountRole) error {
-	if !resources.IsValidServiceAccountRole(role) {
+func addUserToCompany(ctx context.Context, client *client.APIClient, companyID, userEmail string, role resources.IAMRole) error {
+	if !resources.IsValidIAMRole(role) {
 		return fmt.Errorf("invalid service account role %s", role)
 	}
 

--- a/internal/cmd/company/iam/user/create_test.go
+++ b/internal/cmd/company/iam/user/create_test.go
@@ -32,41 +32,41 @@ func TestAddUser(t *testing.T) {
 	testCases := map[string]struct {
 		server    *httptest.Server
 		companyID string
-		role      resources.ServiceAccountRole
+		role      resources.IAMRole
 		userEmail string
 		expectErr bool
 	}{
 		"create user": {
 			server:    addUserTestServer(t),
 			companyID: "success",
-			role:      resources.ServiceAccountRoleGuest,
+			role:      resources.IAMRoleGuest,
 			userEmail: "user@example.com",
 		},
 		"missing company": {
 			server:    addUserTestServer(t),
 			companyID: "",
-			role:      resources.ServiceAccountRoleGuest,
+			role:      resources.IAMRoleGuest,
 			userEmail: "user@example.com",
 			expectErr: true,
 		},
 		"missing email": {
 			server:    addUserTestServer(t),
 			companyID: "success",
-			role:      resources.ServiceAccountRoleGuest,
+			role:      resources.IAMRoleGuest,
 			userEmail: "",
 			expectErr: true,
 		},
 		"wrong role": {
 			server:    addUserTestServer(t),
 			companyID: "",
-			role:      resources.ServiceAccountRole("example"),
+			role:      resources.IAMRole("example"),
 			userEmail: "user@example.com",
 			expectErr: true,
 		},
 		"error from backend": {
 			server:    addUserTestServer(t),
 			companyID: "fail",
-			role:      resources.ServiceAccountRoleCompanyOwner,
+			role:      resources.IAMRoleCompanyOwner,
 			userEmail: "user@example.com",
 			expectErr: true,
 		},

--- a/internal/cmd/company/iam/user/edit.go
+++ b/internal/cmd/company/iam/user/edit.go
@@ -42,22 +42,13 @@ func EditCmd(options *clioptions.CLIOptions) *cobra.Command {
 			client, err := client.APIClientForConfig(restConfig)
 			cobra.CheckErr(err)
 
-			err = editCompanyUser(cmd.Context(), client, restConfig.CompanyID, options.UserID, resources.ServiceAccountRole(options.IAMRole))
+			err = editCompanyUser(cmd.Context(), client, restConfig.CompanyID, options.UserID, resources.IAMRole(options.IAMRole))
 			cobra.CheckErr(err)
 		},
 	}
 
 	options.AddEditUserFlags(cmd.Flags())
-	err := cmd.RegisterFlagCompletionFunc("role", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{
-			resources.ServiceAccountRoleGuest.String(),
-			resources.ServiceAccountRoleReporter.String(),
-			resources.ServiceAccountRoleDeveloper.String(),
-			resources.ServiceAccountRoleMaintainer.String(),
-			resources.ServiceAccountRoleProjectAdmin.String(),
-			resources.ServiceAccountRoleCompanyOwner.String(),
-		}, cobra.ShellCompDirectiveDefault
-	})
+	err := cmd.RegisterFlagCompletionFunc("role", resources.IAMRoleCompletion)
 
 	if err != nil {
 		// we panic here because if we reach here, something nasty is happening in flag autocomplete registration
@@ -67,8 +58,8 @@ func EditCmd(options *clioptions.CLIOptions) *cobra.Command {
 	return cmd
 }
 
-func editCompanyUser(ctx context.Context, client *client.APIClient, companyID, userID string, role resources.ServiceAccountRole) error {
-	if !resources.IsValidServiceAccountRole(role) {
+func editCompanyUser(ctx context.Context, client *client.APIClient, companyID, userID string, role resources.IAMRole) error {
+	if !resources.IsValidIAMRole(role) {
 		return fmt.Errorf("invalid service account role %s", role)
 	}
 
@@ -80,7 +71,7 @@ func editCompanyUser(ctx context.Context, client *client.APIClient, companyID, u
 		return fmt.Errorf("the user id is required")
 	}
 
-	payload := resources.AddUserRequest{
+	payload := resources.EditIAMRole{
 		Role: role,
 	}
 

--- a/internal/cmd/company/iam/user/edit.go
+++ b/internal/cmd/company/iam/user/edit.go
@@ -1,0 +1,108 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package user
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mia-platform/miactl/internal/client"
+	"github.com/mia-platform/miactl/internal/clioptions"
+	"github.com/mia-platform/miactl/internal/resources"
+	"github.com/spf13/cobra"
+)
+
+const (
+	editUserRoleTemplate = "/api/companies/%s/users/%s"
+)
+
+func EditCmd(options *clioptions.CLIOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "user",
+		Short: "Edit a user in a company",
+		Long:  "Edit a user in a company",
+
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			restConfig, err := options.ToRESTConfig()
+			cobra.CheckErr(err)
+			client, err := client.APIClientForConfig(restConfig)
+			cobra.CheckErr(err)
+
+			err = editCompanyUser(cmd.Context(), client, restConfig.CompanyID, options.UserID, resources.ServiceAccountRole(options.IAMRole))
+			cobra.CheckErr(err)
+		},
+	}
+
+	options.AddEditUserFlags(cmd.Flags())
+	err := cmd.RegisterFlagCompletionFunc("role", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{
+			resources.ServiceAccountRoleGuest.String(),
+			resources.ServiceAccountRoleReporter.String(),
+			resources.ServiceAccountRoleDeveloper.String(),
+			resources.ServiceAccountRoleMaintainer.String(),
+			resources.ServiceAccountRoleProjectAdmin.String(),
+			resources.ServiceAccountRoleCompanyOwner.String(),
+		}, cobra.ShellCompDirectiveDefault
+	})
+
+	if err != nil {
+		// we panic here because if we reach here, something nasty is happening in flag autocomplete registration
+		panic(err)
+	}
+
+	return cmd
+}
+
+func editCompanyUser(ctx context.Context, client *client.APIClient, companyID, userID string, role resources.ServiceAccountRole) error {
+	if !resources.IsValidServiceAccountRole(role) {
+		return fmt.Errorf("invalid service account role %s", role)
+	}
+
+	if len(companyID) == 0 {
+		return fmt.Errorf("company id is required, please set it via flag or context")
+	}
+
+	if len(userID) == 0 {
+		return fmt.Errorf("the user id is required")
+	}
+
+	payload := resources.AddUserRequest{
+		Role: role,
+	}
+
+	body, err := resources.EncodeResourceToJSON(payload)
+	if err != nil {
+		return fmt.Errorf("failed to encode request body: %w", err)
+	}
+
+	resp, err := client.
+		Patch().
+		APIPath(fmt.Sprintf(editUserRoleTemplate, companyID, userID)).
+		Body(body).
+		Do(ctx)
+
+	if err != nil {
+		return err
+	}
+
+	if err := resp.Error(); err != nil {
+		return err
+	}
+
+	fmt.Printf("user %s role successfully updated", userID)
+	return nil
+}

--- a/internal/cmd/company/iam/user/edit_test.go
+++ b/internal/cmd/company/iam/user/edit_test.go
@@ -28,46 +28,46 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAddUser(t *testing.T) {
+func TestEditUser(t *testing.T) {
 	testCases := map[string]struct {
 		server    *httptest.Server
 		companyID string
 		role      resources.ServiceAccountRole
-		userEmail string
+		userID    string
 		expectErr bool
 	}{
 		"create user": {
-			server:    addUserTestServer(t),
+			server:    editUserTestServer(t),
 			companyID: "success",
 			role:      resources.ServiceAccountRoleGuest,
-			userEmail: "user@example.com",
+			userID:    "000000000000000000000001",
 		},
 		"missing company": {
-			server:    addUserTestServer(t),
+			server:    editUserTestServer(t),
 			companyID: "",
 			role:      resources.ServiceAccountRoleGuest,
-			userEmail: "user@example.com",
+			userID:    "000000000000000000000001",
 			expectErr: true,
 		},
-		"missing email": {
-			server:    addUserTestServer(t),
+		"missing user id": {
+			server:    editUserTestServer(t),
 			companyID: "success",
 			role:      resources.ServiceAccountRoleGuest,
-			userEmail: "",
+			userID:    "",
 			expectErr: true,
 		},
 		"wrong role": {
-			server:    addUserTestServer(t),
+			server:    editUserTestServer(t),
 			companyID: "",
 			role:      resources.ServiceAccountRole("example"),
-			userEmail: "user@example.com",
+			userID:    "000000000000000000000001",
 			expectErr: true,
 		},
 		"error from backend": {
-			server:    addUserTestServer(t),
+			server:    editUserTestServer(t),
 			companyID: "fail",
 			role:      resources.ServiceAccountRoleCompanyOwner,
-			userEmail: "user@example.com",
+			userID:    "000000000000000000000001",
 			expectErr: true,
 		},
 	}
@@ -80,11 +80,11 @@ func TestAddUser(t *testing.T) {
 				Host: server.URL,
 			})
 			require.NoError(t, err)
-			err = addUserToCompany(
+			err = editCompanyUser(
 				context.TODO(),
 				client,
 				testCase.companyID,
-				testCase.userEmail,
+				testCase.userID,
 				testCase.role,
 			)
 
@@ -98,14 +98,14 @@ func TestAddUser(t *testing.T) {
 	}
 }
 
-func addUserTestServer(t *testing.T) *httptest.Server {
+func editUserTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf(addUserToCompanyTemplate, "success"):
+		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf(editUserRoleTemplate, "success", "000000000000000000000001"):
 			w.WriteHeader(http.StatusOK)
-		case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf(addUserToCompanyTemplate, "fail"):
+		case r.Method == http.MethodPatch && r.URL.Path == fmt.Sprintf(editUserRoleTemplate, "fail", "000000000000000000000001"):
 			w.WriteHeader(http.StatusBadRequest)
 		default:
 			require.Fail(t, "request not implemented", "request received for %s with %s method", r.URL, r.Method)

--- a/internal/resources/requests.go
+++ b/internal/resources/requests.go
@@ -25,25 +25,29 @@ type RefreshTokenRequest struct {
 }
 
 type ServiceAccountRequest struct {
-	Name      string             `json:"name"`
-	Type      string             `json:"tokenEndpointAuthMethod"` //nolint: tagliatelle
-	Role      ServiceAccountRole `json:"role"`
-	PublicKey PublicKey          `json:"publicKey,omitempty"`
+	Name      string    `json:"name"`
+	Type      string    `json:"tokenEndpointAuthMethod"` //nolint: tagliatelle
+	Role      IAMRole   `json:"role"`
+	PublicKey PublicKey `json:"publicKey,omitempty"`
 }
 
 type AddUserRequest struct {
-	Email string             `json:"email"`
-	Role  ServiceAccountRole `json:"role"`
+	Email string  `json:"email"`
+	Role  IAMRole `json:"role"`
 }
 
 type CreateGroupRequest struct {
-	Name    string             `json:"name"`
-	Role    ServiceAccountRole `json:"role"`
-	Members []string           `json:"members"`
+	Name    string   `json:"name"`
+	Role    IAMRole  `json:"role"`
+	Members []string `json:"members"`
 }
 
 type AddMembersToGroup struct {
 	Members []string `json:"emails"` //nolint: tagliatelle
+}
+
+type EditIAMRole struct {
+	Role IAMRole `json:"role"`
 }
 
 type PublicKey struct {
@@ -55,18 +59,18 @@ type PublicKey struct {
 	Exponent  string `json:"e"`   //nolint: tagliatelle
 }
 
-type ServiceAccountRole string
+type IAMRole string
 
 const (
 	ServiceAccountBasic = "client_secret_basic"
 	ServiceAccountJWT   = "private_key_jwt"
 
-	ServiceAccountRoleGuest        = ServiceAccountRole("guest")
-	ServiceAccountRoleReporter     = ServiceAccountRole("reporter")
-	ServiceAccountRoleDeveloper    = ServiceAccountRole("developer")
-	ServiceAccountRoleMaintainer   = ServiceAccountRole("maintainer")
-	ServiceAccountRoleProjectAdmin = ServiceAccountRole("project-admin")
-	ServiceAccountRoleCompanyOwner = ServiceAccountRole("company-owner")
+	IAMRoleGuest        = IAMRole("guest")
+	IAMRoleReporter     = IAMRole("reporter")
+	IAMRoleDeveloper    = IAMRole("developer")
+	IAMRoleMaintainer   = IAMRole("maintainer")
+	IAMRoleProjectAdmin = IAMRole("project-admin")
+	IAMRoleCompanyOwner = IAMRole("company-owner")
 )
 
 type DeployProjectRequest struct {

--- a/internal/resources/utils.go
+++ b/internal/resources/utils.go
@@ -18,22 +18,25 @@ package resources
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
+
+	"github.com/spf13/cobra"
 )
 
-var validServiceAccountRoles = []ServiceAccountRole{
-	ServiceAccountRoleGuest,
-	ServiceAccountRoleReporter,
-	ServiceAccountRoleDeveloper,
-	ServiceAccountRoleMaintainer,
-	ServiceAccountRoleProjectAdmin,
-	ServiceAccountRoleCompanyOwner,
+var validServiceAccountRoles = []IAMRole{
+	IAMRoleGuest,
+	IAMRoleReporter,
+	IAMRoleDeveloper,
+	IAMRoleMaintainer,
+	IAMRoleProjectAdmin,
+	IAMRoleCompanyOwner,
 }
 
-func (role ServiceAccountRole) String() string {
+func (role IAMRole) String() string {
 	return string(role)
 }
 
-func IsValidServiceAccountRole(role ServiceAccountRole) bool {
+func IsValidIAMRole(role IAMRole) bool {
 	for _, validRole := range validServiceAccountRoles {
 		if validRole == role {
 			return true
@@ -41,6 +44,30 @@ func IsValidServiceAccountRole(role ServiceAccountRole) bool {
 	}
 
 	return false
+}
+
+func IAMRoleCompletion(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	allRoles := []string{
+		IAMRoleGuest.String(),
+		IAMRoleReporter.String(),
+		IAMRoleDeveloper.String(),
+		IAMRoleMaintainer.String(),
+		IAMRoleProjectAdmin.String(),
+		IAMRoleCompanyOwner.String(),
+	}
+
+	if len(toComplete) == 0 {
+		return allRoles, cobra.ShellCompDirectiveDefault
+	}
+
+	var completableRole []string
+	for _, role := range allRoles {
+		if strings.HasPrefix(role, toComplete) {
+			completableRole = append(completableRole, role)
+		}
+	}
+
+	return completableRole, cobra.ShellCompDirectiveDefault
 }
 
 func EncodeResourceToJSON(obj interface{}) ([]byte, error) {

--- a/internal/resources/utils_test.go
+++ b/internal/resources/utils_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestIsValidRole(t *testing.T) {
 	for _, role := range validServiceAccountRoles {
-		require.True(t, IsValidServiceAccountRole(role))
+		require.True(t, IsValidIAMRole(role))
 	}
-	require.False(t, IsValidServiceAccountRole("wrong-role"))
+	require.False(t, IsValidIAMRole("wrong-role"))
 }


### PR DESCRIPTION
## What this PR is for?

This PR will add all the various edit commands for the IAM resources of a company and tidy up the completion code for the roles shared between multiple commands to be easier to change and maintain in the future.