### PR TITLE
fix: documentation link in root command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update uuid to 1.5.0
 - update exp to v0.0.0-20231219180239-dc181d75b848
 
-### Fixed
-- correct documentation link in root command
-
 ## [0.10.0] - 2023-12-20
 
 ### BREAKING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update uuid to 1.5.0
 - update exp to v0.0.0-20231219180239-dc181d75b848
 
+### Fixed
+- correct documentation link in root command
+
 ## [0.10.0] - 2023-12-20
 
 ### BREAKING

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -32,7 +32,7 @@ func NewRootCommand() *cobra.Command {
 		Short: "Mia-Platform Console CLI",
 		Long: `miactl is a CLI for interacting with Mia-Platform Console
 
-	Find more information at: https://docs.example.org/docs/cli/miactl/overview`,
+	Find more information at: https://docs.mia-platform.eu/docs/cli/miactl/overview`,
 	}
 
 	// initialize clioptions and setup during initialization


### PR DESCRIPTION
## What this PR is for?

The documentation link shown in the root cmd pointed to example.org, fixed to mia-platform.eu