### PR TITLE
fix: remove conflicting flag from marketplace delete command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update uuid to 1.5.0
 - update exp to v0.0.0-20231219180239-dc181d75b848
 
+### Fixed
+
+- remove conflicting shortand flag `-v` from `miactl marketplace delete` command
+
 ## [0.10.0] - 2023-12-20
 
 ### BREAKING

--- a/internal/clioptions/clioptions.go
+++ b/internal/clioptions/clioptions.go
@@ -200,7 +200,7 @@ func (o *CLIOptions) AddMarketplaceItemObjectIDFlag(flags *pflag.FlagSet) (flagN
 
 func (o *CLIOptions) AddMarketplaceVersionFlag(flags *pflag.FlagSet) (flagName string) {
 	flagName = "version"
-	flags.StringVarP(&o.MarketplaceItemVersion, flagName, "v", "", "The version of the Marketplace item")
+	flags.StringVarP(&o.MarketplaceItemVersion, flagName, "", "", "The version of the Marketplace item")
 	return
 }
 


### PR DESCRIPTION
Remove the conflicting shorthand flag `-v` for flag `--version` of the command `miactl marketplace delete`