### PR TITLE
fix: marketplace list with context companyID

### DIFF
--- a/docs/30_commands.md
+++ b/docs/30_commands.md
@@ -480,7 +480,7 @@ Available flags for the command:
 
 #### edit RESOURCE-NAME
 
-The `project iam edit` subcommand allows you to alternatevely update the role assigned to the current project or
+The `project iam edit` subcommand allows you to alternatively update the role assigned to the current project or
 one of its environment for one of the different `IAM` entity types:
 
 - `group`
@@ -511,7 +511,7 @@ Available flags for the command:
 
 #### remove-role RESOURCE-NAME
 
-The `project iam remove-role` subcommand allows you to alternatevely delete the custom role assigned to one of the
+The `project iam remove-role` subcommand allows you to alternatively delete the custom role assigned to one of the
 different `IAM` entity types for the project or one of its environments.
 
 Usage:

--- a/internal/cmd/marketplace/list.go
+++ b/internal/cmd/marketplace/list.go
@@ -61,13 +61,8 @@ func runListCmd(options *clioptions.CLIOptions) func(cmd *cobra.Command, args []
 		apiClient, err := client.APIClientForConfig(restConfig)
 		cobra.CheckErr(err)
 
-		companyID := restConfig.CompanyID
-		if options.CompanyID != "" {
-			companyID = options.CompanyID
-		}
-
 		marketplaceItemsOptions := GetMarketplaceItemsOptions{
-			companyID: companyID,
+			companyID: restConfig.CompanyID,
 			public:    options.MarketplaceFetchPublicItems,
 		}
 

--- a/internal/cmd/marketplace/list.go
+++ b/internal/cmd/marketplace/list.go
@@ -34,7 +34,7 @@ const (
 
     This command lists the Marketplace items of a company.
 
-    you can also speficfy following flags:
+    you can also specify following flags:
     - --public - if this flag is set, the command fetches not only the items from the requested company, but also the public Marketplace items from other companies.
     `
 	listCmdUse = "list --company-id company-id [FLAGS]..."
@@ -61,8 +61,13 @@ func runListCmd(options *clioptions.CLIOptions) func(cmd *cobra.Command, args []
 		apiClient, err := client.APIClientForConfig(restConfig)
 		cobra.CheckErr(err)
 
+		companyID := restConfig.CompanyID
+		if options.CompanyID != "" {
+			companyID = options.CompanyID
+		}
+
 		marketplaceItemsOptions := GetMarketplaceItemsOptions{
-			companyID: options.CompanyID,
+			companyID: companyID,
 			public:    options.MarketplaceFetchPublicItems,
 		}
 

--- a/internal/cmd/marketplace/list.go
+++ b/internal/cmd/marketplace/list.go
@@ -34,7 +34,7 @@ const (
 
     This command lists the Marketplace items of a company.
 
-    you can also specify following flags:
+    you can also specify the following flags:
     - --public - if this flag is set, the command fetches not only the items from the requested company, but also the public Marketplace items from other companies.
     `
 	listCmdUse = "list --company-id company-id [FLAGS]..."


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
of the work you have done and be sure to link to the relative open issue if is present.

Be aware that all the work you have done should include also the relative tests to assure the
correct behavior and avoid possible regressions in the future.
-->

## What this PR is for?

Fix `miactl marketplace list` to use context `company-id` when not specified as cli option
