### PR TITLE
fix: `marketplace apply` cmd output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - better memory allocation for slices
 - update uuid to v1.6.0
 - update oauth2 to v0.17.0
+- marketplace apply: fix output column headers ID to correct OBJECT ID
 
 ## [0.12.1] - 2024-02-29
 

--- a/internal/cmd/marketplace/apply/apply_test.go
+++ b/internal/cmd/marketplace/apply/apply_test.go
@@ -349,7 +349,7 @@ func TestApplyPrintApplyOutcome(t *testing.T) {
 		require.Contains(t, found, "id4")
 		require.Contains(t, found, "item-id-4")
 		require.Contains(t, found, "some validation error")
-		require.Contains(t, found, "ID")
+		require.Contains(t, found, "OBJECT ID")
 		require.Contains(t, found, "ITEM ID")
 	})
 
@@ -407,7 +407,7 @@ func TestApplyPrintApplyOutcome(t *testing.T) {
 		require.Contains(t, found, "some-item-id-3")
 		require.Contains(t, found, "some-item-id-2")
 		require.Contains(t, found, "some-item-id-1")
-		require.Contains(t, found, "ID")
+		require.Contains(t, found, "OBJECT ID")
 		require.Contains(t, found, "ITEM ID")
 	})
 
@@ -449,7 +449,7 @@ func TestApplyPrintApplyOutcome(t *testing.T) {
 		require.Contains(t, found, "some-item-id-2")
 		require.Contains(t, found, "id3")
 		require.Contains(t, found, "some-item-id-3")
-		require.Contains(t, found, "ID")
+		require.Contains(t, found, "OBJECT ID")
 		require.Contains(t, found, "ITEM ID")
 		require.NotContains(t, found, "items have not been applied due to validation errors:")
 	})

--- a/internal/cmd/marketplace/apply/table.go
+++ b/internal/cmd/marketplace/apply/table.go
@@ -44,7 +44,7 @@ func buildTable(headers []string, items []marketplace.ApplyResponseItem, columnT
 }
 
 func buildSuccessTable(items []marketplace.ApplyResponseItem) string {
-	headers := []string{"ID", "Item ID", "Status"}
+	headers := []string{"Object ID", "Item ID", "Status"}
 	columnTransform := func(item marketplace.ApplyResponseItem) []string {
 		var status string
 		switch {
@@ -63,7 +63,7 @@ func buildSuccessTable(items []marketplace.ApplyResponseItem) string {
 }
 
 func buildFailureTable(items []marketplace.ApplyResponseItem) string {
-	headers := []string{"ID", "Item ID", "Validation Errors"}
+	headers := []string{"Object ID", "Item ID", "Validation Errors"}
 	columnTransform := func(item marketplace.ApplyResponseItem) []string {
 		var validationErrorsStr string
 		validationErrors := item.ValidationErrors


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
of the work you have done and be sure to link to the relative open issue if is present.

Be aware that all the work you have done should include also the relative tests to assure the
correct behavior and avoid possible regressions in the future.
-->

## What this PR is for?

Fix the output of the `miactl marketplace apply` command to display `OBJECT ID` rather than `ID`  for consistency with other commands.