### PR TITLE
Fix github url ghr to gchr and updated docker syntax

### DIFF
--- a/docs/20_setup.md
+++ b/docs/20_setup.md
@@ -75,7 +75,7 @@ sudo mv /tmp/miactl /usr/local/bin
 If you want to run the cli in its environment or you want to test the cli you can use the Docker image:
 
 ```sh
-docker run ghcr.io/mia-platform/miactl:0.12.1 miactl
+docker run ghcr.io/mia-platform/miactl:v0.12.1 miactl
 ```
 
 ### Windows

--- a/docs/20_setup.md
+++ b/docs/20_setup.md
@@ -75,7 +75,7 @@ sudo mv /tmp/miactl /usr/local/bin
 If you want to run the cli in its environment or you want to test the cli you can use the Docker image:
 
 ```sh
-docker run ghr.io/mia-platform/miactl@0.12.1 miactl
+docker run ghcr.io/mia-platform/miactl:0.12.1 miactl
 ```
 
 ### Windows


### PR DESCRIPTION
## What this PR is for?

Updated link to github from `ghr.io` to `gchr.io`