### PR TITLE
Added context to auth

### DIFF
--- a/docs/30_commands.md
+++ b/docs/30_commands.md
@@ -69,7 +69,7 @@ miactl context list
 The `context auth` subcommand allows you to setup the Console Service Account you want to use to authenticate to the Console.
 
 ```sh
-miactl context auth CONTEXT [flags]
+miactl context auth NAME [flags]
 ```
 
 Available flags:

--- a/docs/30_commands.md
+++ b/docs/30_commands.md
@@ -69,14 +69,14 @@ miactl context list
 The `context auth` subcommand allows you to setup the Console Service Account you want to use to authenticate to the Console.
 
 ```sh
-miactl context auth [flags]
+miactl context auth CONTEXT [flags]
 ```
 
 Available flags:
-`--client-id string`: the client ID of the service account
-`--client-secret string`: the client secret of the service account
-`-h, --help`: help for auth
-`--jwt-json string`: path of the json containing the json config of a jwt service account
+- `--client-id string`: the client ID of the service account
+- `--client-secret string`: the client secret of the service account
+- `-h, --help`: help for auth
+- `--jwt-json string`: path of the json containing the json config of a jwt service account
 
 ## company
 


### PR DESCRIPTION
## What this PR is for?
Added the context name to the `miactl auth` command, without context `miactl auth` does not work