### PR TITLE
fix: sends environment query params when get the deploy status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `extensions get` command
 
+### Fixed
+
+- deploy status now sends the environment query params
+
 ## [0.13.0] - 2024-06-26
 
 ### Added

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -84,7 +84,7 @@ func run(ctx context.Context, environmentName string, options *clioptions.CLIOpt
 	}
 	fmt.Printf("Deploying project %s in the environment '%s'\n", projectID, environmentName)
 
-	status, err := waitStatus(ctx, client, projectID, resp.ID)
+	status, err := waitStatus(ctx, client, projectID, resp.ID, environmentName)
 	if err != nil {
 		return fmt.Errorf("error retrieving the pipeline status: %w", err)
 	}
@@ -136,13 +136,14 @@ func triggerPipeline(ctx context.Context, client *client.APIClient, environmentN
 // Declared here to override it during tests
 var sleepDuration = (1 * time.Second) + (500 * time.Millisecond)
 
-func waitStatus(ctx context.Context, client *client.APIClient, projectID string, deployID int) (string, error) {
+func waitStatus(ctx context.Context, client *client.APIClient, projectID string, deployID int, environmentName string) (string, error) {
 	var outStatus *resources.PipelineStatus
 	for {
 		time.Sleep(sleepDuration)
 		resp, err := client.
 			Get().
 			APIPath(fmt.Sprintf(pipelineStatusEndpointTemplate, projectID, deployID)).
+			SetParam("environment", environmentName).
 			Do(ctx)
 
 		if err != nil {

--- a/internal/cmd/deploy/deploy_test.go
+++ b/internal/cmd/deploy/deploy_test.go
@@ -80,7 +80,7 @@ func testServer(t *testing.T) *httptest.Server {
 
 			require.NoError(t, err)
 			w.Write(data)
-		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf(pipelineStatusEndpointTemplate, "correct", 1):
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf(pipelineStatusEndpointTemplate, "correct", 1) && r.URL.Query().Get("environment") == "environmentName":
 			data, err := resources.EncodeResourceToJSON(&resources.PipelineStatus{
 				ID:     1,
 				Status: "succeeded",


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
of the work you have done and be sure to link to the relative open issue if is present.

Be aware that all the work you have done should include also the relative tests to assure the
correct behavior and avoid possible regressions in the future.
-->

## What this PR is for?

<!--
Describe what this PR is trying to achieve, for example is this a PR that fix an open issue? Is for a new feature? etc.
-->

**Which issue(s) this PR fixes:**
<!--
Link any associated issues with this PR for automatically close them when the PR is merged. You can reference them
with only `#<issue number>` or via the full link to the issue.
-->

Fixes a bug get deploy status in provider which differs from gitlab.
