### PR TITLE
feat: marketplace features removed from alpha build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - deprecate `deploy` command
 - update go version to 1.22.5
+- `marketplace list-versions` command removed from alpha build
 
 ## [v0.14.0] - 2024-07-25
 

--- a/internal/cmd/marketplace.go
+++ b/internal/cmd/marketplace.go
@@ -19,7 +19,6 @@ import (
 	"github.com/mia-platform/miactl/internal/clioptions"
 	"github.com/mia-platform/miactl/internal/cmd/marketplace"
 	marketplace_apply "github.com/mia-platform/miactl/internal/cmd/marketplace/apply"
-	"github.com/mia-platform/miactl/internal/util"
 	"github.com/spf13/cobra"
 )
 
@@ -40,11 +39,7 @@ func MarketplaceCmd(options *clioptions.CLIOptions) *cobra.Command {
 	cmd.AddCommand(marketplace.GetCmd(options))
 	cmd.AddCommand(marketplace.DeleteCmd(options))
 	cmd.AddCommand(marketplace_apply.ApplyCmd(options))
-
-	// ALPHA commands
-	if util.AlphaCommandsEnabled() {
-		cmd.AddCommand(marketplace.ListVersionCmd(options))
-	}
+	cmd.AddCommand(marketplace.ListVersionCmd(options))
 
 	return cmd
 }

--- a/internal/cmd/marketplace/delete.go
+++ b/internal/cmd/marketplace/delete.go
@@ -42,7 +42,7 @@ const (
 	Passing the ObjectID is expected only when dealing with deprecated Marketplace items missing the itemId and/or version fields.
 	Otherwise, it is preferable to pass the tuple companyId-itemId-version.
 	`
-	cmdDeleteStableUse = "delete { --item-id item-id --version version } | --object-id object-id [flags]..."
+	cmdDeleteUse = "delete { --item-id item-id --version version } | --object-id object-id [flags]..."
 )
 
 var (
@@ -53,7 +53,7 @@ var (
 // DeleteCmd return a new cobra command for deleting a single marketplace resource
 func DeleteCmd(options *clioptions.CLIOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:        cmdDeleteStableUse,
+		Use:        cmdDeleteUse,
 		Short:      "Delete a Marketplace item",
 		Long:       cmdDeleteStableLong,
 		SuggestFor: []string{"rm"},

--- a/internal/cmd/marketplace/delete.go
+++ b/internal/cmd/marketplace/delete.go
@@ -33,7 +33,7 @@ const (
 	// deleteItemByTupleEndpointTemplate formatting template for item deletion by the tuple itemID versionID endpoint; specify companyID, itemID, version
 	deleteItemByTupleEndpointTemplate = "/api/backend/marketplace/tenants/%s/resources/%s/versions/%s"
 
-	cmdDeleteStableLong = `Delete a single Marketplace item
+	cmdDeleteLongDescription = `Delete a single Marketplace item
 
 	You need to specify either:
 	- the companyId, itemId and version, via the respective flags (recommended). The company-id flag can be omitted if it is already set in the context.
@@ -42,7 +42,7 @@ const (
 	Passing the ObjectID is expected only when dealing with deprecated Marketplace items missing the itemId and/or version fields.
 	Otherwise, it is preferable to pass the tuple companyId-itemId-version.
 	`
-	cmdDeleteUse = "delete { --item-id item-id --version version } | --object-id object-id [flags]..."
+	cmdUse = "delete { --item-id item-id --version version } | --object-id object-id [flags]..."
 )
 
 var (
@@ -53,9 +53,9 @@ var (
 // DeleteCmd return a new cobra command for deleting a single marketplace resource
 func DeleteCmd(options *clioptions.CLIOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:        cmdDeleteUse,
+		Use:        cmdUse,
 		Short:      "Delete a Marketplace item",
-		Long:       cmdDeleteStableLong,
+		Long:       cmdDeleteLongDescription,
 		SuggestFor: []string{"rm"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			restConfig, err := options.ToRESTConfig()

--- a/internal/cmd/marketplace/delete.go
+++ b/internal/cmd/marketplace/delete.go
@@ -24,7 +24,6 @@ import (
 	"github.com/mia-platform/miactl/internal/client"
 	"github.com/mia-platform/miactl/internal/clioptions"
 	"github.com/mia-platform/miactl/internal/resources/marketplace"
-	"github.com/mia-platform/miactl/internal/util"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +33,7 @@ const (
 	// deleteItemByTupleEndpointTemplate formatting template for item deletion by the tuple itemID versionID endpoint; specify companyID, itemID, version
 	deleteItemByTupleEndpointTemplate = "/api/backend/marketplace/tenants/%s/resources/%s/versions/%s"
 
-	cmdDeleteAlphaLong = `Delete a single Marketplace item
+	cmdDeleteStableLong = `Delete a single Marketplace item
 
 	You need to specify either:
 	- the companyId, itemId and version, via the respective flags (recommended). The company-id flag can be omitted if it is already set in the context.
@@ -43,13 +42,7 @@ const (
 	Passing the ObjectID is expected only when dealing with deprecated Marketplace items missing the itemId and/or version fields.
 	Otherwise, it is preferable to pass the tuple companyId-itemId-version.
 	`
-	cmdDeleteStableLong = `Delete a single Marketplace item
-
-	You need to specify the ObjectID of the item with the flag object-id.
-	`
-
-	cmdDeleteAlphaUse  = "delete { --item-id item-id --version version } | --object-id object-id [flags]..."
-	cmdDeleteStableUse = "delete --object-id object-id [flags]..."
+	cmdDeleteStableUse = "delete { --item-id item-id --version version } | --object-id object-id [flags]..."
 )
 
 var (
@@ -59,19 +52,10 @@ var (
 
 // DeleteCmd return a new cobra command for deleting a single marketplace resource
 func DeleteCmd(options *clioptions.CLIOptions) *cobra.Command {
-	var long, use string
-	if util.AlphaCommandsEnabled() {
-		long = cmdDeleteAlphaLong
-		use = cmdDeleteAlphaUse
-	} else {
-		long = cmdDeleteStableLong
-		use = cmdDeleteStableUse
-	}
-
 	cmd := &cobra.Command{
-		Use:        use,
+		Use:        cmdDeleteStableUse,
 		Short:      "Delete a Marketplace item",
-		Long:       long,
+		Long:       cmdDeleteStableLong,
 		SuggestFor: []string{"rm"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			restConfig, err := options.ToRESTConfig()
@@ -108,17 +92,13 @@ func DeleteCmd(options *clioptions.CLIOptions) *cobra.Command {
 
 	itemObjectIDFlagName := options.AddMarketplaceItemObjectIDFlag(cmd.Flags())
 
-	if util.AlphaCommandsEnabled() {
-		itemIDFlagName := options.AddMarketplaceItemIDFlag(cmd.Flags())
-		versionFlagName := options.AddMarketplaceVersionFlag(cmd.Flags())
+	itemIDFlagName := options.AddMarketplaceItemIDFlag(cmd.Flags())
+	versionFlagName := options.AddMarketplaceVersionFlag(cmd.Flags())
 
-		cmd.MarkFlagsRequiredTogether(itemIDFlagName, versionFlagName)
-		cmd.MarkFlagsMutuallyExclusive(itemObjectIDFlagName, itemIDFlagName)
-		cmd.MarkFlagsMutuallyExclusive(itemObjectIDFlagName, versionFlagName)
-		cmd.MarkFlagsOneRequired(itemObjectIDFlagName, itemIDFlagName, versionFlagName)
-	} else {
-		cmd.MarkFlagsOneRequired(itemObjectIDFlagName)
-	}
+	cmd.MarkFlagsRequiredTogether(itemIDFlagName, versionFlagName)
+	cmd.MarkFlagsMutuallyExclusive(itemObjectIDFlagName, itemIDFlagName)
+	cmd.MarkFlagsMutuallyExclusive(itemObjectIDFlagName, versionFlagName)
+	cmd.MarkFlagsOneRequired(itemObjectIDFlagName, itemIDFlagName, versionFlagName)
 
 	return cmd
 }

--- a/internal/cmd/marketplace/get.go
+++ b/internal/cmd/marketplace/get.go
@@ -30,7 +30,7 @@ const (
 	getItemByObjectIDEndpointTemplate         = "/api/backend/marketplace/%s"
 	getItemByItemIDAndVersionEndpointTemplate = "/api/backend/marketplace/tenants/%s/resources/%s/versions/%s"
 
-	cmdGetStableLong = `Get a single Marketplace item
+	cmdGetLongDescription = `Get a single Marketplace item
 
 	You need to specify either:
 	- the companyId, itemId and version, via the respective flags (recommended). The company-id flag can be omitted if it is already set in the context.
@@ -39,15 +39,15 @@ const (
 	Passing the ObjectID is expected only when dealing with deprecated Marketplace items missing the itemId and/or version fields.
 	Otherwise, it is preferable to pass the tuple companyId-itemId-version.
 	`
-	cmdGetStableUse = "get { --item-id item-id --version version } | --object-id object-id [FLAGS]..."
+	cmdGetUse = "get { --item-id item-id --version version } | --object-id object-id [FLAGS]..."
 )
 
 // GetCmd return a new cobra command for getting a single marketplace resource
 func GetCmd(options *clioptions.CLIOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   cmdGetStableUse,
+		Use:   cmdGetUse,
 		Short: "Get Marketplace item",
-		Long:  cmdGetStableLong,
+		Long:  cmdGetLongDescription,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			restConfig, err := options.ToRESTConfig()
 			cobra.CheckErr(err)

--- a/internal/cmd/marketplace/get.go
+++ b/internal/cmd/marketplace/get.go
@@ -23,7 +23,6 @@ import (
 	"github.com/mia-platform/miactl/internal/clioptions"
 	"github.com/mia-platform/miactl/internal/encoding"
 	"github.com/mia-platform/miactl/internal/resources/marketplace"
-	"github.com/mia-platform/miactl/internal/util"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +30,7 @@ const (
 	getItemByObjectIDEndpointTemplate         = "/api/backend/marketplace/%s"
 	getItemByItemIDAndVersionEndpointTemplate = "/api/backend/marketplace/tenants/%s/resources/%s/versions/%s"
 
-	cmdGetAlphaLong = `Get a single Marketplace item
+	cmdGetStableLong = `Get a single Marketplace item
 
 	You need to specify either:
 	- the companyId, itemId and version, via the respective flags (recommended). The company-id flag can be omitted if it is already set in the context.
@@ -40,29 +39,15 @@ const (
 	Passing the ObjectID is expected only when dealing with deprecated Marketplace items missing the itemId and/or version fields.
 	Otherwise, it is preferable to pass the tuple companyId-itemId-version.
 	`
-	cmdGetStableLong = `Get a single Marketplace item
-
-	You need to specify the ObjectID of the item with the flag object-id
-	`
-	cmdGetAlphaUse  = "get { --item-id item-id --version version } | --object-id object-id [FLAGS]..."
-	cmdGetStableUse = "get --object-id object-id [FLAGS]..."
+	cmdGetStableUse = "get { --item-id item-id --version version } | --object-id object-id [FLAGS]..."
 )
 
 // GetCmd return a new cobra command for getting a single marketplace resource
 func GetCmd(options *clioptions.CLIOptions) *cobra.Command {
-	var long, use string
-	if util.AlphaCommandsEnabled() {
-		long = cmdGetAlphaLong
-		use = cmdGetAlphaUse
-	} else {
-		long = cmdGetStableLong
-		use = cmdGetStableUse
-	}
-
 	cmd := &cobra.Command{
-		Use:   use,
+		Use:   cmdGetStableUse,
 		Short: "Get Marketplace item",
-		Long:  long,
+		Long:  cmdGetStableLong,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			restConfig, err := options.ToRESTConfig()
 			cobra.CheckErr(err)
@@ -89,17 +74,13 @@ func GetCmd(options *clioptions.CLIOptions) *cobra.Command {
 
 	itemObjectIDFlagName := options.AddMarketplaceItemObjectIDFlag(cmd.Flags())
 
-	if util.AlphaCommandsEnabled() {
-		itemIDFlagName := options.AddMarketplaceItemIDFlag(cmd.Flags())
-		versionFlagName := options.AddMarketplaceVersionFlag(cmd.Flags())
+	itemIDFlagName := options.AddMarketplaceItemIDFlag(cmd.Flags())
+	versionFlagName := options.AddMarketplaceVersionFlag(cmd.Flags())
 
-		cmd.MarkFlagsRequiredTogether(itemIDFlagName, versionFlagName)
-		cmd.MarkFlagsMutuallyExclusive(itemObjectIDFlagName, itemIDFlagName)
-		cmd.MarkFlagsMutuallyExclusive(itemObjectIDFlagName, versionFlagName)
-		cmd.MarkFlagsOneRequired(itemObjectIDFlagName, itemIDFlagName, versionFlagName)
-	} else {
-		cmd.MarkFlagsOneRequired(itemObjectIDFlagName)
-	}
+	cmd.MarkFlagsRequiredTogether(itemIDFlagName, versionFlagName)
+	cmd.MarkFlagsMutuallyExclusive(itemObjectIDFlagName, itemIDFlagName)
+	cmd.MarkFlagsMutuallyExclusive(itemObjectIDFlagName, versionFlagName)
+	cmd.MarkFlagsOneRequired(itemObjectIDFlagName, itemIDFlagName, versionFlagName)
 
 	return cmd
 }

--- a/internal/cmd/marketplace/list_versions.go
+++ b/internal/cmd/marketplace/list_versions.go
@@ -38,11 +38,9 @@ var (
 func ListVersionCmd(options *clioptions.CLIOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list-versions",
-		Short: "List versions of a Marketplace item (ALPHA)",
+		Short: "List versions of a Marketplace item",
 		Long: `List the currently available versions of a Marketplace item.
-The command will output a table with each version of the item.
-
-This command is in ALPHA state. This means that it can be subject to breaking changes in the next versions of miactl.`,
+The command will output a table with each version of the item.`,
 		Run: func(cmd *cobra.Command, _ []string) {
 			restConfig, err := options.ToRESTConfig()
 			cobra.CheckErr(err)


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
of the work you have done and be sure to link to the relative open issue if is present.

Be aware that all the work you have done should include also the relative tests to assure the
correct behavior and avoid possible regressions in the future.
-->

## What this PR is for?

<!--
Describe what this PR is trying to achieve, for example is this a PR that fix an open issue? Is for a new feature? etc.
-->

Removes from alpha build:

- `marketplace list-versions`
- `marketplace get` (only description updates)
- `marketplace delete` (only description updates)

From now on, these information (and the retrieval/deletion of marketplace items via itemId and tenantId) are available by default.
