### PR TITLE
fix: typo in commands doc

### DIFF
--- a/docs/30_commands.md
+++ b/docs/30_commands.md
@@ -436,7 +436,7 @@ Available flags for the command:
 Rules command helps you manage different rules for configuration update for the whole Company or specific Projects.
 
 :::tip
-This feature is currently in closed preview and may be subject to breaking changes, reach out to your Mia-Platorm referent
+This feature is currently in closed preview and may be subject to breaking changes, reach out to your Mia-Platform referent
 if you are interested in use it.
 :::
 
@@ -453,7 +453,7 @@ miactl company rules list [flags]
 Available flags for the command:
 
 - `--company-id`, the id of the Company
-- `--project-id`, the id of the Project (if provided the command will print avilable rules for the project,
+- `--project-id`, the id of the Project (if provided the command will print available rules for the project,
   together with the rules inherited from the Company)
 
 #### update


### PR DESCRIPTION
## What this PR is for?

There were a few typos in the doc
