### PR TITLE
Manage deploy pipeline error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update oauth2 to v0.25.0
 - update sync to v0.10.0
 - update text to v0.21.0
+- update `deploy trigger` command to handle deployment pipeline failure
 
 ## [v0.16.0] - 2024-11-21
 

--- a/internal/cmd/deploy/trigger.go
+++ b/internal/cmd/deploy/trigger.go
@@ -93,6 +93,10 @@ func runDeployTrigger(ctx context.Context, environmentName string, options *clio
 		return fmt.Errorf("error retrieving the pipeline status: %w", err)
 	}
 
+	if status == "failed" {
+		return fmt.Errorf("Pipeline failed")
+	}
+
 	fmt.Printf("Pipeline ended with %s\n", status)
 	return nil
 }

--- a/internal/cmd/deploy/trigger_test.go
+++ b/internal/cmd/deploy/trigger_test.go
@@ -41,11 +41,6 @@ func TestDeploy(t *testing.T) {
 			server:    testTriggerServer(t),
 			projectID: "correct",
 		},
-		"pipeline failed": {
-			server:    testTriggerServer(t),
-			projectID: "failed",
-			expectErr: true,
-		},
 		"pipeline fails": {
 			server:    testTriggerServer(t),
 			projectID: "fails-bad-request",
@@ -87,7 +82,7 @@ func testTriggerServer(t *testing.T) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Helper()
 		switch {
-		case r.Method == http.MethodPost && (r.URL.Path == fmt.Sprintf(deployProjectEndpointTemplate, "correct") || r.URL.Path == fmt.Sprintf(deployProjectEndpointTemplate, "fails-wait-status") || r.URL.Path == fmt.Sprintf(deployProjectEndpointTemplate, "failed")):
+		case r.Method == http.MethodPost && (r.URL.Path == fmt.Sprintf(deployProjectEndpointTemplate, "correct") || r.URL.Path == fmt.Sprintf(deployProjectEndpointTemplate, "fails-wait-status")):
 			data, err := resources.EncodeResourceToJSON(&resources.DeployProject{
 				ID:  1,
 				URL: "http://example.com",

--- a/internal/cmd/deploy/trigger_test.go
+++ b/internal/cmd/deploy/trigger_test.go
@@ -41,6 +41,11 @@ func TestDeploy(t *testing.T) {
 			server:    testTriggerServer(t),
 			projectID: "correct",
 		},
+		"pipeline failed": {
+			server:    testFailedTriggerServer(t),
+			projectID: "failed",
+			expectErr: true,
+		},
 		"pipeline fails": {
 			server:    testTriggerServer(t),
 			projectID: "fails-bad-request",
@@ -97,13 +102,6 @@ func testTriggerServer(t *testing.T) *httptest.Server {
 			})
 			require.NoError(t, err)
 			w.Write(data)
-		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf(pipelineStatusEndpointTemplate, "failed", 1) && r.URL.Query().Get("environment") == "environmentName":
-			data, err := resources.EncodeResourceToJSON(&resources.PipelineStatus{
-				ID:     1,
-				Status: "failed",
-			})
-			require.NoError(t, err)
-			w.Write(data)
 		case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf(deployProjectEndpointTemplate, "fails-bad-request"):
 			respBody := `{"error": "Bad Request","message":"some bad request"}`
 
@@ -114,6 +112,35 @@ func testTriggerServer(t *testing.T) *httptest.Server {
 
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(respBody))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			require.FailNowf(t, "unknown http request", "request method: %s request URL: %s", r.Method, r.URL)
+		}
+	}))
+
+	return server
+}
+
+func testFailedTriggerServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Helper()
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf(deployProjectEndpointTemplate, "failed"):
+			data, err := resources.EncodeResourceToJSON(&resources.DeployProject{
+				ID:  1,
+				URL: "http://example.com",
+			})
+
+			require.NoError(t, err)
+			w.Write(data)
+		case r.Method == http.MethodGet && r.URL.Path == fmt.Sprintf(pipelineStatusEndpointTemplate, "failed", 1) && r.URL.Query().Get("environment") == "environmentName":
+			data, err := resources.EncodeResourceToJSON(&resources.PipelineStatus{
+				ID:     1,
+				Status: "failed",
+			})
+			require.NoError(t, err)
+			w.Write(data)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 			require.FailNowf(t, "unknown http request", "request method: %s request URL: %s", r.Method, r.URL)


### PR DESCRIPTION
Right now the miactl deploy command return ok even when the pipeline ends with failure.
Using this command in a pipeline would mean to have a job that failed its operation but in the UI is succeeded.

With this PR, when the deploy fails the command returns an error "pipeline failed". 
