### PR TITLE
Read from errors field in apply items response body to display errors

### DIFF
--- a/internal/cmd/marketplace/apply/apply_test.go
+++ b/internal/cmd/marketplace/apply/apply_test.go
@@ -334,20 +334,40 @@ func TestApplyPrintApplyOutcome(t *testing.T) {
 						},
 					},
 				},
+				{
+					ID:       "id5",
+					ItemID:   "item-id-5",
+					Done:     false,
+					Inserted: false,
+					Updated:  false,
+					ValidationErrors: []marketplace.ApplyResponseItemValidationError{
+						{
+							Message: "some validation error",
+						},
+					},
+					Errors: []marketplace.ApplyResponseItemValidationError{
+						{
+							Message: "some validation error in errors field",
+						},
+					},
+				},
 			},
 		}
 		found := buildOutcomeSummaryAsTables(mockOutcome)
-		require.Contains(t, found, "3 of 4 items have been successfully applied:")
+		require.Contains(t, found, "3 of 5 items have been successfully applied:")
 		require.Contains(t, found, "id1")
 		require.Contains(t, found, "item-id-1")
 		require.Contains(t, found, "id2")
 		require.Contains(t, found, "item-id-2")
 		require.Contains(t, found, "id3")
 		require.Contains(t, found, "item-id-3")
-		require.Contains(t, found, "1 of 4 items have not been applied due to validation errors:")
+		require.Contains(t, found, "2 of 5 items have not been applied due to validation errors:")
 		require.Contains(t, found, "id4")
 		require.Contains(t, found, "item-id-4")
 		require.Contains(t, found, "some validation error")
+		require.Contains(t, found, "id5")
+		require.Contains(t, found, "item-id-5")
+		require.Contains(t, found, "some validation error in errors field")
 		require.Contains(t, found, "OBJECT ID")
 		require.Contains(t, found, "ITEM ID")
 	})

--- a/internal/cmd/marketplace/apply/apply_test.go
+++ b/internal/cmd/marketplace/apply/apply_test.go
@@ -351,17 +351,26 @@ func TestApplyPrintApplyOutcome(t *testing.T) {
 						},
 					},
 				},
+				{
+					ID:       "id6",
+					ItemID:   "item-id-6",
+					Done:     true,
+					Inserted: true,
+					Updated:  false,
+				},
 			},
 		}
 		found := buildOutcomeSummaryAsTables(mockOutcome)
-		require.Contains(t, found, "3 of 5 items have been successfully applied:")
+		require.Contains(t, found, "4 of 6 items have been successfully applied:")
 		require.Contains(t, found, "id1")
 		require.Contains(t, found, "item-id-1")
 		require.Contains(t, found, "id2")
 		require.Contains(t, found, "item-id-2")
 		require.Contains(t, found, "id3")
 		require.Contains(t, found, "item-id-3")
-		require.Contains(t, found, "2 of 5 items have not been applied due to validation errors:")
+		require.Contains(t, found, "id6")
+		require.Contains(t, found, "item-id-6")
+		require.Contains(t, found, "2 of 6 items have not been applied due to validation errors:")
 		require.Contains(t, found, "id4")
 		require.Contains(t, found, "item-id-4")
 		require.Contains(t, found, "some validation error")

--- a/internal/cmd/marketplace/apply/table.go
+++ b/internal/cmd/marketplace/apply/table.go
@@ -60,7 +60,12 @@ func buildFailureTable(items []marketplace.ApplyResponseItem) string {
 	headers := []string{"Object ID", "Item ID", "Validation Errors"}
 	columnTransform := func(item marketplace.ApplyResponseItem) []string {
 		var validationErrorsStr string
-		validationErrors := item.ValidationErrors
+		var validationErrors []marketplace.ApplyResponseItemValidationError
+		if len(item.Errors) > 0 {
+			validationErrors = item.Errors
+		} else {
+			validationErrors = item.ValidationErrors
+		}
 		for i, valErr := range validationErrors {
 			validationErrorsStr += valErr.Message
 			if len(validationErrors)-1 > i {

--- a/internal/resources/marketplace/marketplace.go
+++ b/internal/resources/marketplace/marketplace.go
@@ -46,6 +46,7 @@ type ApplyResponseItem struct {
 	Updated  bool `json:"updated"`
 
 	ValidationErrors []ApplyResponseItemValidationError `json:"validationErrors"`
+	Errors           []ApplyResponseItemValidationError `json:"errors"`
 }
 
 type ApplyResponseItemValidationError struct {


### PR DESCRIPTION
## What this PR is for?

Marketplace API, in particular the POST apply items, now has a new field that describes better the error regarding the item. I edited how the table is built so that now it shows the `errors` field, if exists.
