### PR TITLE
refactor: changed marketplace api prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### BREAKING
+
+**Starting from this version, `miactl` is compatible only with Mia-Platform Console v13.2.1 or higher.**
+
+The breaking change consists of:
+
+- marketplace endpoints use `/api/marketplace` prefix instead of `/api/backend/marketplace`.
+
 ## [v0.17.2] - 2025-03-04
 
 ### Changed

--- a/internal/cmd/marketplace/apply/apply.go
+++ b/internal/cmd/marketplace/apply/apply.go
@@ -61,7 +61,7 @@ miactl marketplace apply -f ./path/to/myFantasticGoTemplate.json -f ./path/to/my
 # Apply all the valid configuration files in the directory myFantasticGoTemplates to the Marketplace
 miactl marketplace apply -f myFantasticGoTemplates`
 
-	applyEndpointTemplate = "/api/backend/marketplace/tenants/%s/resources"
+	applyEndpointTemplate = "/api/marketplace/tenants/%s/resources"
 
 	imageAssetType = "imageAssetType"
 	imageKey       = "image"

--- a/internal/cmd/marketplace/apply/upload_image.go
+++ b/internal/cmd/marketplace/apply/upload_image.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	uploadImageEndpointTemplate = "/api/backend/marketplace/tenants/%s/files"
+	uploadImageEndpointTemplate = "/api/marketplace/tenants/%s/files"
 	multipartFieldName          = "marketplace_image"
 
 	localPathKey = "localPath"

--- a/internal/cmd/marketplace/delete.go
+++ b/internal/cmd/marketplace/delete.go
@@ -29,9 +29,9 @@ import (
 
 const (
 	// deleteItemEndpointTemplate formatting template for item deletion by objectID backend endpoint; specify tenantID, objectID
-	deleteItemEndpointTemplate = "/api/backend/marketplace/tenants/%s/resources/%s"
+	deleteItemEndpointTemplate = "/api/marketplace/tenants/%s/resources/%s"
 	// deleteItemByTupleEndpointTemplate formatting template for item deletion by the tuple itemID versionID endpoint; specify companyID, itemID, version
-	deleteItemByTupleEndpointTemplate = "/api/backend/marketplace/tenants/%s/resources/%s/versions/%s"
+	deleteItemByTupleEndpointTemplate = "/api/marketplace/tenants/%s/resources/%s/versions/%s"
 
 	cmdDeleteLongDescription = `Delete a single Marketplace item
 

--- a/internal/cmd/marketplace/get.go
+++ b/internal/cmd/marketplace/get.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	getItemByObjectIDEndpointTemplate         = "/api/backend/marketplace/%s"
-	getItemByItemIDAndVersionEndpointTemplate = "/api/backend/marketplace/tenants/%s/resources/%s/versions/%s"
+	getItemByObjectIDEndpointTemplate         = "/api/marketplace/%s"
+	getItemByItemIDAndVersionEndpointTemplate = "/api/marketplace/tenants/%s/resources/%s/versions/%s"
 
 	cmdGetLongDescription = `Get a single Marketplace item
 

--- a/internal/cmd/marketplace/list.go
+++ b/internal/cmd/marketplace/list.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	listMarketplaceEndpoint = "/api/backend/marketplace/"
+	listMarketplaceEndpoint = "/api/marketplace/"
 	listCmdLong             = `List Marketplace items
 
     This command lists the Marketplace items of a company.

--- a/internal/cmd/marketplace/list_test.go
+++ b/internal/cmd/marketplace/list_test.go
@@ -125,7 +125,7 @@ func TestBuildMarketplaceItemsList(t *testing.T) {
 func privateAndPublicMarketplaceHandler(t *testing.T) http.HandlerFunc {
 	t.Helper()
 	return func(w http.ResponseWriter, r *http.Request) {
-		if strings.EqualFold(r.URL.Path, "/api/backend/marketplace/") &&
+		if strings.EqualFold(r.URL.Path, "/api/marketplace/") &&
 			r.Method == http.MethodGet &&
 			r.URL.Query().Get("includeTenantId") == "my-company" {
 			_, err := w.Write([]byte(marketplaceItemsBodyContent(t)))
@@ -140,7 +140,7 @@ func privateAndPublicMarketplaceHandler(t *testing.T) http.HandlerFunc {
 func privateCompanyMarketplaceHandler(t *testing.T) http.HandlerFunc {
 	t.Helper()
 	return func(w http.ResponseWriter, r *http.Request) {
-		if strings.EqualFold(r.URL.Path, "/api/backend/marketplace/") &&
+		if strings.EqualFold(r.URL.Path, "/api/marketplace/") &&
 			r.Method == http.MethodGet &&
 			r.URL.Query().Get("tenantId") == "my-company" {
 			_, err := w.Write([]byte(marketplacePrivateCompanyBodyContent(t)))
@@ -155,7 +155,7 @@ func privateCompanyMarketplaceHandler(t *testing.T) http.HandlerFunc {
 func wrongPayloadHandler(t *testing.T) http.HandlerFunc {
 	t.Helper()
 	return func(w http.ResponseWriter, r *http.Request) {
-		if strings.EqualFold(r.URL.Path, "/api/backend/marketplace/") &&
+		if strings.EqualFold(r.URL.Path, "/api/marketplace/") &&
 			r.Method == http.MethodGet &&
 			r.URL.Query().Get("tenantId") == "my-company" {
 			_, err := w.Write([]byte("{}")) // Incorrect payload

--- a/internal/cmd/marketplace/list_versions.go
+++ b/internal/cmd/marketplace/list_versions.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const listItemVersionsEndpointTemplate = "/api/backend/marketplace/tenants/%s/resources/%s/versions"
+const listItemVersionsEndpointTemplate = "/api/marketplace/tenants/%s/resources/%s/versions"
 
 var (
 	ErrGenericServerError = errors.New("server error while fetching item versions")


### PR DESCRIPTION
## What this PR is for?

The aim of this PR is to change the marketplace API endpoints from `/api/backend/marketplace` to `/api/marketplace` because endpoints with `/api/backend/marketplace` prefix have been deprecated.

**It also means that `miactl` won't be compatible with older Mia-Platform Console versions (v13.2.0 or below). I wrote it in the CHANGELOG file.**
