### PR TITLE
Fixes output stream for project description

### DIFF
--- a/internal/cmd/project/describe.go
+++ b/internal/cmd/project/describe.go
@@ -60,7 +60,7 @@ func DescribeCmd(options *clioptions.CLIOptions) *cobra.Command {
 				OutputFormat: options.OutputFormat,
 			}
 
-			return describeProject(cmd.Context(), client, cmdOptions, cmd.ErrOrStderr())
+			return describeProject(cmd.Context(), client, cmdOptions, cmd.OutOrStdout())
 		},
 	}
 


### PR DESCRIPTION
Updates the project description command to use the standard output stream instead of the error stream.

This ensures that the command's output is correctly captured and displayed to the user.
