### PR TITLE
Fix errors in commands with version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed error management in commands with Console version check
+
 ### Changed
 
 - update go version to 1.25.1

--- a/internal/cmd/catalog/apply/apply.go
+++ b/internal/cmd/catalog/apply/apply.go
@@ -83,7 +83,10 @@ func ApplyCmd(options *clioptions.CLIOptions) *cobra.Command {
 			cobra.CheckErr(err)
 
 			canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), client, 14, 0)
-			if !canUseNewAPI || versionError != nil {
+			if versionError != nil {
+				return versionError
+			}
+			if !canUseNewAPI {
 				return catalog.ErrUnsupportedCompanyVersion
 			}
 

--- a/internal/cmd/catalog/delete.go
+++ b/internal/cmd/catalog/delete.go
@@ -56,7 +56,10 @@ func DeleteCmd(options *clioptions.CLIOptions) *cobra.Command {
 			cobra.CheckErr(err)
 
 			canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), client, 14, 0)
-			if !canUseNewAPI || versionError != nil {
+			if versionError != nil {
+				return versionError
+			}
+			if !canUseNewAPI {
 				return catalog.ErrUnsupportedCompanyVersion
 			}
 

--- a/internal/cmd/catalog/get.go
+++ b/internal/cmd/catalog/get.go
@@ -54,7 +54,10 @@ func GetCmd(options *clioptions.CLIOptions) *cobra.Command {
 			cobra.CheckErr(err)
 
 			canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), client, 14, 0)
-			if !canUseNewAPI || versionError != nil {
+			if versionError != nil {
+				return versionError
+			}
+			if !canUseNewAPI {
 				return catalog.ErrUnsupportedCompanyVersion
 			}
 

--- a/internal/cmd/catalog/list.go
+++ b/internal/cmd/catalog/list.go
@@ -62,7 +62,10 @@ func runListCmd(options *clioptions.CLIOptions) func(cmd *cobra.Command, args []
 		cobra.CheckErr(err)
 
 		canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), apiClient, 14, 0)
-		if !canUseNewAPI || versionError != nil {
+		if versionError != nil {
+			return versionError
+		}
+		if !canUseNewAPI {
 			return catalog.ErrUnsupportedCompanyVersion
 		}
 

--- a/internal/cmd/catalog/list_versions.go
+++ b/internal/cmd/catalog/list_versions.go
@@ -40,7 +40,10 @@ The command will output a table with each version of the item. It works with Mia
 			cobra.CheckErr(err)
 
 			canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), client, 14, 0)
-			if !canUseNewAPI || versionError != nil {
+			if versionError != nil {
+				return versionError
+			}
+			if !canUseNewAPI {
 				return catalog.ErrUnsupportedCompanyVersion
 			}
 

--- a/internal/cmd/item-type-definition/delete.go
+++ b/internal/cmd/item-type-definition/delete.go
@@ -56,7 +56,10 @@ func DeleteCmd(options *clioptions.CLIOptions) *cobra.Command {
 			cobra.CheckErr(err)
 
 			canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), client, 14, 1)
-			if !canUseNewAPI || versionError != nil {
+			if versionError != nil {
+				return versionError
+			}
+			if !canUseNewAPI {
 				return itd.ErrUnsupportedCompanyVersion
 			}
 

--- a/internal/cmd/item-type-definition/get.go
+++ b/internal/cmd/item-type-definition/get.go
@@ -49,7 +49,10 @@ func GetCmd(options *clioptions.CLIOptions) *cobra.Command {
 			cobra.CheckErr(err)
 
 			canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), client, 14, 1)
-			if !canUseNewAPI || versionError != nil {
+			if versionError != nil {
+				return versionError
+			}
+			if !canUseNewAPI {
 				return itd.ErrUnsupportedCompanyVersion
 			}
 

--- a/internal/cmd/item-type-definition/list.go
+++ b/internal/cmd/item-type-definition/list.go
@@ -71,7 +71,10 @@ func runListCmd(options *clioptions.CLIOptions) func(cmd *cobra.Command, args []
 		cobra.CheckErr(err)
 
 		canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), apiClient, 14, 1)
-		if !canUseNewAPI || versionError != nil {
+		if versionError != nil {
+			return versionError
+		}
+		if !canUseNewAPI {
 			return itd.ErrUnsupportedCompanyVersion
 		}
 

--- a/internal/cmd/item-type-definition/put.go
+++ b/internal/cmd/item-type-definition/put.go
@@ -73,7 +73,10 @@ func PutCmd(options *clioptions.CLIOptions) *cobra.Command {
 			cobra.CheckErr(err)
 
 			canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), client, 14, 1)
-			if !canUseNewAPI || versionError != nil {
+			if versionError != nil {
+				return versionError
+			}
+			if !canUseNewAPI {
 				return itd.ErrUnsupportedCompanyVersion
 			}
 


### PR DESCRIPTION
## What this PR is for?

Some commands use the VersionCheck function but when it is used, a console version error is always shown regardless of the error. The PR fixes this behaviour and shows a different error when the HTTP call fails.