### PR TITLE
feat: add Windows native binary support

### DIFF
--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -1,0 +1,43 @@
+name: Release Windows Binary
+
+on:
+  push:
+    branches:
+    - main
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    name: Build and release miactl.exe
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        show-progress: false
+
+    - name: Setup Golang
+      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      with:
+        go-version-file: go.mod
+
+    - name: Build Windows binary
+      run: |
+        GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build \
+          -trimpath \
+          -ldflags "-s -w" \
+          -o miactl.exe \
+          ./cmd/miactl
+
+    - name: Publish latest-windows release
+      run: |
+        gh release delete latest-windows --yes 2>/dev/null || true
+        gh release create latest-windows \
+          --title "Latest Windows Build ($(git rev-parse --short HEAD))" \
+          --notes "Auto-built Windows amd64 binary from commit $(git rev-parse HEAD)." \
+          --prerelease \
+          miactl.exe
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/internal/authorization/browser_windows.go
+++ b/internal/authorization/browser_windows.go
@@ -1,0 +1,23 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authorization
+
+import "os/exec"
+
+func openBrowser(url string) error {
+	cmd := exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	return cmd.Run()
+}


### PR DESCRIPTION
## Summary

- Adds `browser_windows.go` — the missing Windows implementation of `openBrowser` (using `rundll32 url.dll,FileProtocolHandler`), matching the pattern of the existing `browser_darwin.go` and `browser_linux.go`
- Adds `.github/workflows/release-windows.yaml` — cross-compiles `miactl.exe` (windows/amd64) on every push to `main` and publishes it as a rolling pre-release tagged `latest-windows` using only `GITHUB_TOKEN`

## Why

`miactl` has no official Windows binary. Teams running on Windows currently work around this with WSL, which adds friction and a hard dependency on a Linux subsystem. A native binary removes that dependency entirely.

The release workflow intentionally avoids the upstream Goreleaser/Homebrew machinery (which requires `BOT_GITHUB_TOKEN`) and instead uses a simple rolling pre-release so the latest build is always available via:

```
gh release download latest-windows --repo <fork> --pattern miactl.exe
```

## Changes

| File | Change |
|---|---|
| `internal/authorization/browser_windows.go` | New — Windows `openBrowser` implementation |
| `.github/workflows/release-windows.yaml` | New — Windows cross-compile + rolling release workflow |

## Test plan

- [ ] Confirm `release-windows` workflow runs green on merge
- [ ] Confirm `latest-windows` pre-release appears with `miactl.exe` asset
- [ ] Download binary, run `miactl --version` to confirm it executes natively on Windows
- [ ] Run `miactl auth login` to exercise the `openBrowser` path on Windows