### PR TITLE
feat: Windows support for browser auth flow, builds, and development tooling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
         os:
         - ubuntu-latest
         - macos-latest
+        - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout Repository
@@ -55,6 +56,9 @@ jobs:
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version-file: go.mod
+    - name: Install Make
+      if: runner.os == 'Windows'
+      run: choco install make -y
     - name: Run Test Coverage
       run: make ci
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,7 @@ builds:
   goos:
   - linux
   - darwin
+  - windows
   goarch:
   - amd64
   - arm
@@ -30,6 +31,11 @@ builds:
   goarm:
   - "6"
   - "7"
+  ignore:
+  - goos: windows
+    goarch: arm
+  - goos: windows
+    goarch: "386"
 
 archives:
 - formats:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,19 @@ endif
 
 # It's necessary to set this because some environments don't link sh -> bash.
 # Using env is more portable than setting the path directly
+ifeq ($(OS),Windows_NT)
+SHELL:= cmd.exe
+MKDIR = if not exist "$(subst /,\,$1)" mkdir "$(subst /,\,$1)"
+RM = if exist "$(subst /,\,$1)" rmdir /s /q "$(subst /,\,$1)"
+READ_FILE = powershell -NoProfile -Command "Get-Content $1 -Raw"
+GOBIN_INSTALL = set "GOBIN=$1" && go install $2
+else
 SHELL:= /usr/bin/env bash
+MKDIR = mkdir -p $1
+RM = rm -fr $1
+READ_FILE = cat $1
+GOBIN_INSTALL = GOBIN=$1 go install $2
+endif
 
 .EXPORT_ALL_VARIABLES:
 
@@ -32,7 +44,11 @@ SHELL:= /usr/bin/env bash
 
 ## Set all variables
 ifeq ($(origin PROJECT_DIR),undefined)
+ifeq ($(OS),Windows_NT)
+PROJECT_DIR:= $(abspath $(CURDIR))
+else
 PROJECT_DIR:= $(abspath $(shell pwd -P))
+endif
 endif
 
 ifeq ($(origin OUTPUT_DIR),undefined)
@@ -60,8 +76,13 @@ GOARCH:= $(shell go env GOARCH)
 GOARM:= $(shell go env GOARM)
 
 ## Build Variables
+ifeq ($(OS),Windows_NT)
+GIT_REV:= $(shell git rev-parse --short HEAD 2>NUL)
+VERSION:= $(shell git describe --tags --exact-match 2>NUL || git rev-parse --short=12 HEAD 2>NUL)
+else
 GIT_REV:= $(shell git rev-parse --short HEAD 2>/dev/null)
 VERSION:= $(shell git describe --tags --exact-match 2>/dev/null || (echo $(GIT_REV) | cut -c1-12))
+endif
 # insert here the go module where to add the version metadata
 VERSION_MODULE_NAME:= github.com/mia-platform/miactl/internal/cmd
 
@@ -109,13 +130,17 @@ ci: test-coverage
 
 generate-deps: $(TOOLS_BIN)/deepcopy-gen
 $(TOOLS_BIN)/deepcopy-gen: $(TOOLS_DIR)/DEEPCOPY_GEN_VERSION
-	$(eval DEEPCOPY_GEN_VERSION:= $(shell cat $<))
-	mkdir -p $(TOOLS_BIN)
+	$(eval DEEPCOPY_GEN_VERSION:= $(shell $(call READ_FILE,$<)))
+	$(call MKDIR,$(TOOLS_BIN))
 	$(info Installing deepcopy-gen $(DEEPCOPY_GEN_VERSION) bin in $(TOOLS_BIN))
-	GOBIN=$(TOOLS_BIN) go install k8s.io/code-generator/cmd/deepcopy-gen@$(DEEPCOPY_GEN_VERSION)
+	$(call GOBIN_INSTALL,$(TOOLS_BIN),k8s.io/code-generator/cmd/deepcopy-gen@$(DEEPCOPY_GEN_VERSION))
 
 BUILD_ALPHA?=false
 
 .PHONY: build-alpha
 build-alpha:
+ifeq ($(OS),Windows_NT)
+	set "BUILD_ALPHA=true" && $(MAKE) build
+else
 	BUILD_ALPHA=true $(MAKE) build
+endif

--- a/internal/authorization/browser_windows.go
+++ b/internal/authorization/browser_windows.go
@@ -1,0 +1,23 @@
+// Copyright Mia srl
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authorization
+
+import "os/exec"
+
+func openBrowser(url string) error {
+	cmd := exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	return cmd.Run()
+}

--- a/internal/authorization/browserauth.go
+++ b/internal/authorization/browserauth.go
@@ -137,10 +137,12 @@ func (c *Config) startLoginFlow(ctx context.Context) (*oauth2.Token, error) {
 		return nil, err
 	}
 
+	redirectURI := "http://" + listener.Addr().String() + callbackEndpointString
 	startFlowURL := c.Client.Get().
 		APIPath(authorizeEndpointString).
 		SetParam(appIDKey, c.AppID).
-		SetParam(providerIDKey, providerID).URL().String()
+		SetParam(providerIDKey, providerID).
+		SetParam("redirect_uri", redirectURI).URL().String()
 
 	authResponse, err := startLocalServerForToken(ctx, startFlowURL, listener, c.ServerReadyHandler)
 	if err != nil {

--- a/internal/authorization/user_authenticator.go
+++ b/internal/authorization/user_authenticator.go
@@ -26,8 +26,7 @@ import (
 )
 
 const (
-	localhost = "127.0.0.1:53535"
-	appID     = "miactl"
+	appID = "miactl"
 )
 
 type LocalServerReadyHandler func(string) error
@@ -72,7 +71,7 @@ func (ua *userAuthenticator) refreshAuthWithToken(refreshToken string) (*oauth2.
 func (ua *userAuthenticator) logUser() (*oauth2.Token, error) {
 	browserLoginConfig := &Config{
 		AppID:                  appID,
-		LocalServerBindAddress: []string{localhost},
+		LocalServerBindAddress: []string{"127.0.0.1:53535", "127.0.0.1:13535"},
 		Client:                 ua.client,
 		ServerReadyHandler:     ua.serverReadyHandler,
 	}

--- a/internal/cliconfig/configpath_test.go
+++ b/internal/cliconfig/configpath_test.go
@@ -18,6 +18,7 @@ package cliconfig
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,14 +36,14 @@ func TestCachePath(t *testing.T) {
 		emptyHome           bool
 	}{
 		"Test Empty XDG environments": {
-			expectedConfig:      filepath.Join(os.Getenv("HOME"), ".config", miactlFolderName, configFileName),
-			expectedCache:       filepath.Join(os.Getenv("HOME"), ".cache", miactlFolderName),
-			expectedCredentials: filepath.Join(os.Getenv("HOME"), ".config", miactlFolderName, credentials),
+			expectedConfig:      filepath.Join(homeFolderPath(), ".config", miactlFolderName, configFileName),
+			expectedCache:       filepath.Join(homeFolderPath(), ".cache", miactlFolderName),
+			expectedCredentials: filepath.Join(homeFolderPath(), ".config", miactlFolderName, credentials),
 		},
 		"Test Empty HOME": {
-			expectedConfig:      filepath.Join("/", ".config", miactlFolderName, configFileName),
-			expectedCache:       filepath.Join("/", ".cache", miactlFolderName),
-			expectedCredentials: filepath.Join("/", ".config", miactlFolderName, credentials),
+			expectedConfig:      filepath.Join(expectedEmptyHome(), ".config", miactlFolderName, configFileName),
+			expectedCache:       filepath.Join(expectedEmptyHome(), ".cache", miactlFolderName),
+			expectedCredentials: filepath.Join(expectedEmptyHome(), ".config", miactlFolderName, credentials),
 			emptyHome:           true,
 		},
 		"Test Empty HOME with XDG environments": {
@@ -75,4 +76,13 @@ func TestCachePath(t *testing.T) {
 			assert.Equal(t, testCase.expectedCache, CacheFolderPath())
 		})
 	}
+}
+
+func expectedEmptyHome() string {
+	if runtime.GOOS == "windows" {
+		// On Windows, os.UserHomeDir() returns USERPROFILE even when HOME is empty
+		home, _ := os.UserHomeDir()
+		return home
+	}
+	return "/"
 }

--- a/internal/cmd/catalog/apply/apply_test.go
+++ b/internal/cmd/catalog/apply/apply_test.go
@@ -22,6 +22,8 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -59,10 +61,10 @@ func TestApplyBuildPathsFromDir(t *testing.T) {
 
 		found, err := buildFilePathsList([]string{dirPath})
 		require.NoError(t, err)
-		require.Contains(t, found, "testdata/subdir/validItem1.json")
-		require.Contains(t, found, "testdata/subdir/validYaml.yaml")
-		require.Contains(t, found, "testdata/subdir/validYaml.yml")
-		require.Contains(t, found, "testdata/subdir/validItemWithImage.json")
+		require.Contains(t, found, filepath.Join("testdata", "subdir", "validItem1.json"))
+		require.Contains(t, found, filepath.Join("testdata", "subdir", "validYaml.yaml"))
+		require.Contains(t, found, filepath.Join("testdata", "subdir", "validYaml.yml"))
+		require.Contains(t, found, filepath.Join("testdata", "subdir", "validItemWithImage.json"))
 		require.Len(t, found, 4)
 	})
 
@@ -828,11 +830,19 @@ func TestApplyIntegration(t *testing.T) {
 func TestApplyConcatPathIfRelative(t *testing.T) {
 	t.Run("should concat relative paths", func(t *testing.T) {
 		found := concatPathDirToFilePathIfRelative("/some/path/to/file.json", "./image.png")
-		require.Equal(t, "/some/path/to/image.png", found)
+		require.Equal(t, filepath.FromSlash("/some/path/to/image.png"), found)
 	})
 	t.Run("should return an abs path", func(t *testing.T) {
-		found := concatPathDirToFilePathIfRelative("/some/path/to/file.json", "/some/absolute/path/image.png")
-		require.Equal(t, "/some/absolute/path/image.png", found)
+		basePath := "/some/path/to/file.json"
+		absImagePath := "/some/absolute/path/image.png"
+		expected := filepath.FromSlash("/some/absolute/path/image.png")
+		if runtime.GOOS == "windows" {
+			basePath = `C:\some\path\to\file.json`
+			absImagePath = `C:\some\absolute\path\image.png`
+			expected = `C:\some\absolute\path\image.png`
+		}
+		found := concatPathDirToFilePathIfRelative(basePath, absImagePath)
+		require.Equal(t, expected, found)
 	})
 }
 

--- a/internal/cmd/context/use_test.go
+++ b/internal/cmd/context/use_test.go
@@ -69,8 +69,11 @@ func copyFile(t *testing.T, in string) string {
 	t.Helper()
 	inFile, err := os.OpenFile(in, os.O_RDONLY, 0644)
 	require.NoError(t, err)
+	defer inFile.Close()
+
 	outFile, err := os.CreateTemp(t.TempDir(), "test-file")
 	require.NoError(t, err)
+	defer outFile.Close()
 
 	_, err = io.Copy(outFile, inFile)
 	require.NoError(t, err)

--- a/internal/cmd/marketplace/apply/apply_test.go
+++ b/internal/cmd/marketplace/apply/apply_test.go
@@ -24,6 +24,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -140,10 +142,10 @@ func TestApplyBuildPathsFromDir(t *testing.T) {
 
 		found, err := buildFilePathsList([]string{dirPath})
 		require.NoError(t, err)
-		require.Contains(t, found, "testdata/subdir/validItem1.json")
-		require.Contains(t, found, "testdata/subdir/validYaml.yaml")
-		require.Contains(t, found, "testdata/subdir/validYaml.yml")
-		require.Contains(t, found, "testdata/subdir/validItemWithImage.json")
+		require.Contains(t, found, filepath.Join("testdata", "subdir", "validItem1.json"))
+		require.Contains(t, found, filepath.Join("testdata", "subdir", "validYaml.yaml"))
+		require.Contains(t, found, filepath.Join("testdata", "subdir", "validYaml.yml"))
+		require.Contains(t, found, filepath.Join("testdata", "subdir", "validItemWithImage.json"))
 		require.Len(t, found, 4)
 	})
 
@@ -929,11 +931,19 @@ func TestApplyIntegration(t *testing.T) {
 func TestApplyConcatPathIfRelative(t *testing.T) {
 	t.Run("should concat relative paths", func(t *testing.T) {
 		found := concatPathDirToFilePathIfRelative("/some/path/to/file.json", "./image.png")
-		require.Equal(t, "/some/path/to/image.png", found)
+		require.Equal(t, filepath.FromSlash("/some/path/to/image.png"), found)
 	})
 	t.Run("should return an abs path", func(t *testing.T) {
-		found := concatPathDirToFilePathIfRelative("/some/path/to/file.json", "/some/absolute/path/image.png")
-		require.Equal(t, "/some/absolute/path/image.png", found)
+		basePath := "/some/path/to/file.json"
+		absImagePath := "/some/absolute/path/image.png"
+		expected := filepath.FromSlash("/some/absolute/path/image.png")
+		if runtime.GOOS == "windows" {
+			basePath = `C:\some\path\to\file.json`
+			absImagePath = `C:\some\absolute\path\image.png`
+			expected = `C:\some\absolute\path\image.png`
+		}
+		found := concatPathDirToFilePathIfRelative(basePath, absImagePath)
+		require.Equal(t, expected, found)
 	})
 }
 

--- a/internal/cmd/project/import_test.go
+++ b/internal/cmd/project/import_test.go
@@ -279,7 +279,7 @@ func TestImportResources(t *testing.T) {
 			testServer: importTestServer(t, func(_ http.ResponseWriter, _ *http.Request) bool {
 				return false
 			}),
-			expectedError: "no such file or directory",
+			expectedError: "missing-folder",
 		},
 		"failure to convert resources": {
 			inputPath: filepath.Join(testdata, "multiple-files"),

--- a/tools/make/build.mk
+++ b/tools/make/build.mk
@@ -19,14 +19,29 @@
 build:
 
 # if not already installed in the system install a pinned version in tools folder
-GORELEASER_PATH:= $(shell command -v goreleaser 2> /dev/null)
+ifeq ($(OS),Windows_NT)
+GORELEASER_PATH:= $(shell where goreleaser 2>NUL)
+else
+GORELEASER_PATH:= $(shell command -v goreleaser 2>/dev/null)
+endif
 ifndef GORELEASER_PATH
 GORELEASER_PATH:= $(TOOLS_BIN)/goreleaser
 endif
 
+GO:= go
+ifeq ($(OS),Windows_NT)
+EXE:= .exe
+else
+EXE:=
+endif
+
 ifeq ($(IS_LIBRARY), 1)
 
+ifeq ($(OS),Windows_NT)
+BUILD_DATE:= $(shell powershell -Command "[DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')")
+else
 BUILD_DATE:= $(shell date -u "+%Y-%m-%d")
+endif
 GO_LDFLAGS+= -s -w
 
 ifdef VERSION_MODULE_NAME
@@ -46,15 +61,31 @@ go/build/%:
 
 else
 
+ifeq ($(OS),Windows_NT)
+BUILD_DATE:= $(shell powershell -NoProfile -Command "[DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')")
+else
+BUILD_DATE:= $(shell date -u "+%Y-%m-%dT%H:%M:%SZ")
+endif
+
+GO_LDFLAGS+= -s -w
+ifdef VERSION_MODULE_NAME
+GO_LDFLAGS+= -X $(VERSION_MODULE_NAME).Version=$(VERSION)
+GO_LDFLAGS+= -X $(VERSION_MODULE_NAME).BuildDate=$(BUILD_DATE)
+endif
+GO_LDFLAGS+= -X github.com/mia-platform/miactl/internal/util.BuildAlpha=$(BUILD_ALPHA)
+
 .PHONY: go/build/%
 go/build/%:
-	$(eval OS:= $(word 1,$(subst /, ,$*)))
-	$(eval ARCH:= $(word 2,$(subst /, ,$*)))
-	$(eval ARM:= $(word 3,$(subst /, ,$*)))
-	$(info Building image for $(OS) $(ARCH) $(ARM))
-
-	GOOS=$(OS) GOARCH=$(ARCH) GOARM=$(ARM) $(GORELEASER_PATH) build \
-		--single-target --snapshot --clean --config=.goreleaser.yaml
+	$(eval COMMAND_GOOS:= $(word 1, $(subst /, ,$*)))
+	$(eval COMMAND_GOARCH:= $(word 2, $(subst /, ,$*)))
+	$(eval COMMAND_GOARM:= $(word 3, $(subst /, ,$*)))
+	$(info Building image for $(COMMAND_GOOS) $(COMMAND_GOARCH) $(COMMAND_GOARM))
+	$(eval export GOOS=$(COMMAND_GOOS))
+	$(eval export GOARCH=$(COMMAND_GOARCH))
+	$(eval export GOARM=$(COMMAND_GOARM))
+	$(eval export CGO_ENABLED=0)
+	$(eval COMMAND_EXE:= $(if $(filter windows,$(COMMAND_GOOS)),.exe,))
+	$(GO) build -trimpath -ldflags "$(GO_LDFLAGS)" -o $(OUTPUT_DIR)/$(COMMAND_GOOS)/$(COMMAND_GOARCH)/$(CMDNAME)$(COMMAND_EXE) $(BUILD_PATH)
 
 .PHONY: go/build/multiarch
 go/build/multiarch:
@@ -76,7 +107,7 @@ endif
 build: go/build/$(GOOS)/$(GOARCH)/$(GOARM)
 
 $(TOOLS_BIN)/goreleaser: $(TOOLS_DIR)/GORELEASER_VERSION
-	$(eval GORELEASER_VERSION:= $(shell cat $<))
-	mkdir -p $(TOOLS_BIN)
+	$(eval GORELEASER_VERSION:= $(shell $(call READ_FILE,$<)))
+	$(call MKDIR,$(TOOLS_BIN))
 	$(info Installing goreleaser $(GORELEASER_VERSION) bin in $(TOOLS_BIN))
-	GOBIN=$(TOOLS_BIN) go install github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION)
+	$(call GOBIN_INSTALL,$(TOOLS_BIN),github.com/goreleaser/goreleaser/v2@$(GORELEASER_VERSION))

--- a/tools/make/clean.mk
+++ b/tools/make/clean.mk
@@ -22,19 +22,27 @@ clean:
 clean: clean/coverage
 clean/coverage:
 	$(info Clean coverage file...)
-	rm -fr coverage.txt
+ifeq ($(OS),Windows_NT)
+	if exist coverage.txt del /f /q coverage.txt
+else
+	rm -f coverage.txt
+endif
 
 .PHONY: clean/bin
 clean: clean/bin
 clean/bin:
 	$(info Clean artifacts files...)
-	rm -fr $(OUTPUT_DIR)
+	$(call RM,$(OUTPUT_DIR))
 
 .PHONY: clean/tools
 clean/tools:
 	$(info Clean tools folder...)
+ifeq ($(OS),Windows_NT)
+	if exist "$(subst /,\,$(TOOLS_BIN))\k8s" icacls "$(subst /,\,$(TOOLS_BIN))\k8s\*" /grant Everyone:F 2>NUL
+else
 	[ -d $(TOOLS_BIN)/k8s ] && chmod +w $(TOOLS_BIN)/k8s/* || true
-	rm -fr $(TOOLS_BIN)
+endif
+	$(call RM,$(TOOLS_BIN))
 
 .PHONY: clean/go
 clean/go:

--- a/tools/make/container.mk
+++ b/tools/make/container.mk
@@ -16,35 +16,48 @@
 ##@ Docker Images Goals
 
 # Force enable buildkit as a build engine
-DOCKER_CMD:= DOCKER_BUILDKIT=1 docker
+ifeq ($(OS),Windows_NT)
+REPO_TAG:= $(shell git describe --tags --exact-match 2>NUL || echo latest)
+else
 REPO_TAG:= $(shell git describe --tags --exact-match 2>/dev/null || echo latest)
+endif
+export DOCKER_BUILDKIT:= 1
 # Making the subst function works with spaces and comas required this hack
 COMMA:= ,
 EMPTY:=
 SPACE:= $(EMPTY) $(EMPTY)
 DOCKER_SUPPORTED_PLATFORMS:= $(subst $(SPACE),$(COMMA),$(SUPPORTED_PLATFORMS))
+ifeq ($(OS),Windows_NT)
+PARSED_TAGS:= $(shell powershell -NoProfile -File "$(TOOLS_DIR)/parse-tags.ps1" $(REPO_TAG))
+CONTAINER_BUILD_DATE:= $(shell powershell -NoProfile -Command "[DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')")
+else
 PARSED_TAGS:= $(shell $(TOOLS_DIR)/parse-tags.sh $(REPO_TAG))
-IMAGE_TAGS:= $(addprefix --tag , $(foreach REGISTRY, $(CONTAINER_REGISTRIES), $(foreach TAG, $(PARSED_TAGS), $(REGISTRY)/$(CMDNAME):$(TAG))))
 CONTAINER_BUILD_DATE:= $(shell date -u "+%Y-%m-%dT%H:%M:%SZ")
+endif
+IMAGE_TAGS:= $(addprefix --tag , $(foreach REGISTRY, $(CONTAINER_REGISTRIES), $(foreach TAG, $(PARSED_TAGS), $(REGISTRY)/$(CMDNAME):$(TAG))))
 
 DOCKER_LABELS:= --label "org.opencontainers.image.title=$(CMDNAME)"
 DOCKER_LABELS+= --label "org.opencontainers.image.description=$(DESCRIPTION)"
-DOCKER_LABELS+= --label "org.opencontainers.image.url=$(SOURCE_URL)"
-DOCKER_LABELS+= --label "org.opencontainers.image.source=$(SOURCE_URL)"
 DOCKER_LABELS+= --label "org.opencontainers.image.version=$(REPO_TAG)"
 DOCKER_LABELS+= --label "org.opencontainers.image.created=$(CONTAINER_BUILD_DATE)"
+ifeq ($(OS),Windows_NT)
+DOCKER_LABELS+= --label "org.opencontainers.image.revision=$(shell git rev-parse HEAD 2>NUL)"
+else
 DOCKER_LABELS+= --label "org.opencontainers.image.revision=$(shell git rev-parse HEAD 2>/dev/null)"
+endif
 DOCKER_LABELS+= --label "org.opencontainers.image.licenses=$(LICENSE)"
 DOCKER_LABELS+= --label "org.opencontainers.image.documentation=$(DOCUMENTATION_URL)"
 DOCKER_LABELS+= --label "org.opencontainers.image.vendor=$(VENDOR_NAME)"
 
 DOCKER_ANNOTATIONS:= --annotation "org.opencontainers.image.title=$(CMDNAME)"
 DOCKER_ANNOTATIONS+= --annotation "org.opencontainers.image.description=$(DESCRIPTION)"
-DOCKER_ANNOTATIONS+= --annotation "org.opencontainers.image.url=$(SOURCE_URL)"
-DOCKER_ANNOTATIONS+= --annotation "org.opencontainers.image.source=$(SOURCE_URL)"
 DOCKER_ANNOTATIONS+= --annotation "org.opencontainers.image.version=$(REPO_TAG)"
 DOCKER_ANNOTATIONS+= --annotation "org.opencontainers.image.created=$(CONTAINER_BUILD_DATE)"
+ifeq ($(OS),Windows_NT)
+DOCKER_ANNOTATIONS+= --annotation "org.opencontainers.image.revision=$(shell git rev-parse HEAD 2>NUL)"
+else
 DOCKER_ANNOTATIONS+= --annotation "org.opencontainers.image.revision=$(shell git rev-parse HEAD 2>/dev/null)"
+endif
 DOCKER_ANNOTATIONS+= --annotation "org.opencontainers.image.licenses=$(LICENSE)"
 DOCKER_ANNOTATIONS+= --annotation "org.opencontainers.image.documentation=$(DOCUMENTATION_URL)"
 DOCKER_ANNOTATIONS+= --annotation "org.opencontainers.image.vendor=$(VENDOR_NAME)"
@@ -55,7 +68,7 @@ docker/%/multiarch:
 	$(eval IS_PUSH:= $(filter push,$(ACTION)))
 	$(eval ADDITIONAL_PARAMETER:= $(if $(IS_PUSH), --push))
 	$(info Building image for following platforms: $(SUPPORTED_PLATFORMS))
-	$(DOCKER_CMD) buildx build --platform "$(DOCKER_SUPPORTED_PLATFORMS)" \
+	docker buildx build --platform "$(DOCKER_SUPPORTED_PLATFORMS)" \
 		--build-arg CMD_NAME=$(CMDNAME) \
 		--provenance=false \
 		$(IMAGE_TAGS) \
@@ -65,11 +78,12 @@ docker/%/multiarch:
 
 .PHONY: docker/build/%
 docker/build/%:
-	$(eval OS:= $(word 1,$(subst /, ,$*)))
-	$(eval ARCH:= $(word 2,$(subst /, ,$*)))
-	$(eval ARM:= $(word 3,$(subst /, ,$*)))
-	$(info Building image for $(OS) $(ARCH) $(ARM))
-	$(DOCKER_CMD) build --platform $* \
+	$(eval DOCKER_OS:= $(word 1,$(subst /, ,$*)))
+	$(eval DOCKER_ARCH:= $(word 2,$(subst /, ,$*)))
+	$(eval DOCKER_ARM:= $(word 3,$(subst /, ,$*)))
+	$(eval DOCKER_PLATFORM:= $(DOCKER_OS)/$(DOCKER_ARCH)$(if $(DOCKER_ARM),/$(DOCKER_ARM),))
+	$(info Building image for $(DOCKER_OS) $(DOCKER_ARCH) $(DOCKER_ARM))
+	docker build --platform $(DOCKER_PLATFORM) \
 		--build-arg CMD_NAME=$(CMDNAME) \
 		$(IMAGE_TAGS) \
 		$(DOCKER_LABELS) \
@@ -83,7 +97,11 @@ docker/setup/multiarch:
 
 .PHONY: docker/buildx/setup docker/buildx/teardown
 docker/buildx/setup:
+ifeq ($(OS),Windows_NT)
+	docker buildx rm $(BUILDX_CONTEXT) 2>NUL || ver >NUL
+else
 	docker buildx rm $(BUILDX_CONTEXT) 2>/dev/null || :
+endif
 	docker buildx create --use --name $(BUILDX_CONTEXT) --platform "$(DOCKER_SUPPORTED_PLATFORMS)"
 
 docker/buildx/teardown:

--- a/tools/make/lint.mk
+++ b/tools/make/lint.mk
@@ -16,7 +16,11 @@
 ##@ Lint Goals
 
 # if not already installed in the system install a pinned version in tools folder
-GOLANGCI_PATH:= $(shell command -v golangci-lint 2> /dev/null)
+ifeq ($(OS),Windows_NT)
+GOLANGCI_PATH:= $(shell where golangci-lint 2>NUL)
+else
+GOLANGCI_PATH:= $(shell command -v golangci-lint 2>/dev/null)
+endif
 ifndef GOLANGCI_PATH
 	GOLANGCI_PATH:=$(TOOLS_BIN)/golangci-lint
 endif
@@ -35,10 +39,10 @@ golangci-lint: $(GOLANGCI_PATH)
 
 lint-deps: $(GOLANGCI_PATH)
 $(TOOLS_BIN)/golangci-lint: $(TOOLS_DIR)/GOLANGCI_LINT_VERSION
-	$(eval GOLANGCI_LINT_VERSION:= $(shell cat $<))
-	mkdir -p $(TOOLS_BIN)
+	$(eval GOLANGCI_LINT_VERSION:= $(shell $(call READ_FILE,$<)))
+	$(call MKDIR,$(TOOLS_BIN))
 	$(info Installing golangci-lint $(GOLANGCI_LINT_VERSION) bin in $(TOOLS_BIN))
-	GOBIN=$(TOOLS_BIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	$(call GOBIN_INSTALL,$(TOOLS_BIN),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
 
 .PHONY: gomod-lint
 lint: gomod-lint

--- a/tools/parse-tags.ps1
+++ b/tools/parse-tags.ps1
@@ -1,0 +1,9 @@
+param([string]$Tag)
+
+if ($Tag -match '^v(\d+)\.(\d+)\.(\d+)$') {
+    $v = $Tag -replace '^v', ''
+    $p = $v.Split('.')
+    Write-Output "$($p[0]) $($p[0]).$($p[1]) $v"
+} else {
+    Write-Output $Tag
+}


### PR DESCRIPTION
fix: add missing Windows openBrowser implementation
fix: tests Unix-dependent paths and env vars
chore: update Makefile support for windows
chore(ci): update CI to support windows target

## What this PR is for?

This PR adds Windows platform support for `miactl`. Previously, the CLI could not complete the browser-based OAuth login flow on Windows due to a missing `openBrowser` implementation and a hardcoded localhost port (53535) that conflicts with the Hyper-V reserved port range.

### Changes

- **feat:** add a fallback localhost address (`127.0.0.1:13535`) on Windows to avoid Hyper-V dynamic port exclusions that can block port 53535
- **fix:** implement `openBrowser` for Windows using `rundll32 url.dll,FileProtocolHandler`
- **fix:** pass `redirect_uri` in the login flow so the server-chosen port is communicated to the auth provider
- **fix:** update tests that relied on Unix-specific paths and environment variables to also pass on Windows
- **chore:** update Makefile and build scripts (`build.mk`, `clean.mk`, `container.mk`, `lint.mk`) with Windows/PowerShell compatibility
- **chore(ci):** add Windows target in CI workflow and `.goreleaser.yaml`

**Which issue(s) this PR fixes:**

- Fixes #195