### PR TITLE
fix: prevent double percent-encoding of URL path segments

### DIFF
--- a/internal/client/request.go
+++ b/internal/client/request.go
@@ -106,13 +106,7 @@ func (r *Request) APIPath(apiPath string) *Request {
 		return r
 	}
 
-	// Use RawPath to preserve percent-encoded segments (e.g. %2F in branch names).
-	// EscapedPath() would double-encode them (e.g. %2F -> %252F).
-	if parsedURI.RawPath != "" {
-		r.apiPath = parsedURI.RawPath
-	} else {
-		r.apiPath = parsedURI.Path
-	}
+	r.apiPath = parsedURI.EscapedPath()
 
 	// comment out this, because not every request support the trailing /
 	// hopefully in the future they will
@@ -139,12 +133,19 @@ func (r *Request) Error() error {
 
 // URL return the url that will be used by the http.Request in this moment
 func (r *Request) URL() *url.URL {
-	url := *r.restClient.baseURL
+	finalURL := *r.restClient.baseURL
 
-	url.Path = strings.TrimSuffix(url.Path, "/") + r.apiPath
-	url.RawQuery = r.params.Encode()
+	finalURL.Path = strings.TrimSuffix(finalURL.Path, "/") + r.apiPath
+	// r.apiPath may contain percent-encoded segments (e.g. %2F for branch names
+	// with slashes). Since url.Path is the decoded field, we must set RawPath
+	// to preserve the original encoding and avoid double percent-encoding.
+	if decodedPath, err := url.PathUnescape(finalURL.Path); err == nil && decodedPath != finalURL.Path {
+		finalURL.RawPath = finalURL.Path
+		finalURL.Path = decodedPath
+	}
+	finalURL.RawQuery = r.params.Encode()
 
-	return &url
+	return &finalURL
 }
 
 // preflightCheck perform checks for human error in setting the request

--- a/internal/client/request.go
+++ b/internal/client/request.go
@@ -106,7 +106,13 @@ func (r *Request) APIPath(apiPath string) *Request {
 		return r
 	}
 
-	r.apiPath = parsedURI.EscapedPath()
+	// Use RawPath to preserve percent-encoded segments (e.g. %2F in branch names).
+	// EscapedPath() would double-encode them (e.g. %2F -> %252F).
+	if parsedURI.RawPath != "" {
+		r.apiPath = parsedURI.RawPath
+	} else {
+		r.apiPath = parsedURI.Path
+	}
 
 	// comment out this, because not every request support the trailing /
 	// hopefully in the future they will

--- a/internal/client/request_test.go
+++ b/internal/client/request_test.go
@@ -119,6 +119,11 @@ func TestRequestURL(t *testing.T) {
 			apiPath:     "/api/backend/projects/",
 			expectedURL: "http://host/mia/api/backend/projects/",
 		},
+		"percent-encoded path segments preserved": {
+			baseURL:     "http://host/",
+			apiPath:     "/api/backend/projects/myProjectID/revisions/feat%2Fexternal-idp/configuration",
+			expectedURL: "http://host/api/backend/projects/myProjectID/revisions/feat%2Fexternal-idp/configuration",
+		},
 	}
 
 	for testName, testCase := range testCases {

--- a/internal/client/request_test.go
+++ b/internal/client/request_test.go
@@ -145,6 +145,13 @@ func TestSetAPIPath(t *testing.T) {
 	// once an error is register no other changes can be made
 	r.APIPath(validPath)
 	assert.Error(t, r.Error())
+
+	// percent-encoded path segments must not be double-encoded
+	r2 := (&Request{})
+	encodedPath := "/api/backend/projects/myProjectID/revisions/feat%2Fexternal-idp/configuration"
+	r2.APIPath(encodedPath)
+	assert.NoError(t, r2.Error())
+	assert.Equal(t, encodedPath, r2.apiPath)
 }
 
 func TestPreflightCheck(t *testing.T) {

--- a/internal/cmd/project/describe_test.go
+++ b/internal/cmd/project/describe_test.go
@@ -178,7 +178,7 @@ func TestDescribeProjectCmd(t *testing.T) {
 				OutputFormat: "yaml",
 			},
 			testServer: describeTestServer(t, func(w http.ResponseWriter, r *http.Request) bool {
-				if r.URL.Path == "/api/backend/projects/test-project/revisions/some%2Frevision/configuration" && r.Method == http.MethodGet {
+				if r.URL.RawPath == "/api/backend/projects/test-project/revisions/some%2Frevision/configuration" && r.Method == http.MethodGet {
 					w.WriteHeader(http.StatusOK)
 					_, _ = w.Write([]byte(`{"name": "test-project", "revision": "test-yaml-revision"}`))
 					return true
@@ -234,7 +234,7 @@ func TestDescribeProjectCmd(t *testing.T) {
 				OutputFormat: "yaml",
 			},
 			testServer: describeTestServer(t, func(w http.ResponseWriter, r *http.Request) bool {
-				if r.URL.Path == "/api/backend/projects/test-project/versions/version%2F1.2.3/configuration" && r.Method == http.MethodGet {
+				if r.URL.RawPath == "/api/backend/projects/test-project/versions/version%2F1.2.3/configuration" && r.Method == http.MethodGet {
 					w.WriteHeader(http.StatusOK)
 					_, _ = w.Write([]byte(`{"name": "test-project", "revision": "test-yaml-revision"}`))
 					return true


### PR DESCRIPTION
## Description

Fixes a bug where branch/revision names containing slashes were double
percent-encoded in API request URLs. For example, `feat/external-idp`
was encoded as `feat%252Fexternal-idp` instead of `feat%2Fexternal-idp`.

## Root Cause

`Request.URL()` in `internal/client/request.go` assigned the encoded
`apiPath` (from `EscapedPath()`, containing `%2F`) directly to
`url.Path`, which in Go's `net/url` package is the **decoded** field.
When `url.String()` later serialized the URL, it called `EscapedPath()`
again, re-encoding the `%` character itself (`%` → `%25`), producing
`%252F`.

## Changes

- In `Request.URL()`, detect when the assembled path contains
  percent-encoded segments and properly split into decoded `url.Path`
  and encoded `url.RawPath`.
- Added a test case to `TestRequestURL` verifying the final URL string
  preserves percent-encoded path segments.
- Fixed test assertions in `TestDescribeProjectCmd` to check `RawPath`
  instead of `Path` for encoded segments, matching correct HTTP
  behavior.

## Testing

All existing tests pass. New test added covering the specific scenario.
