### PR TITLE
fix: handle numeric project id in deploy response deserialization

### DIFF
--- a/internal/resources/responses.go
+++ b/internal/resources/responses.go
@@ -126,9 +126,65 @@ type DeployProject struct {
 	URL string `json:"url"`
 }
 
+func (dp *DeployProject) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		ID  json.RawMessage `json:"id"`
+		URL string          `json:"url"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	dp.URL = raw.URL
+
+	// try string
+	var err error
+	var s string
+	if err = json.Unmarshal(raw.ID, &s); err == nil {
+		dp.ID = s
+		return nil
+	}
+
+	var n json.Number
+	if err = json.Unmarshal(raw.ID, &n); err == nil {
+		dp.ID = n.String()
+		return nil
+	}
+
+	return err
+}
+
 type PipelineStatus struct {
 	ID     string `json:"id"`
 	Status string `json:"status"`
+}
+
+func (dp *PipelineStatus) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		ID     json.RawMessage `json:"id"`
+		Status string          `json:"status"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	dp.Status = raw.Status
+
+	// try string
+	var err error
+	var s string
+	if err = json.Unmarshal(raw.ID, &s); err == nil {
+		dp.ID = s
+		return nil
+	}
+
+	var n json.Number
+	if err = json.Unmarshal(raw.ID, &n); err == nil {
+		dp.ID = n.String()
+		return nil
+	}
+
+	return err
 }
 
 type CreateJob struct {


### PR DESCRIPTION
##Description:

GitLab pipeline trigger responses return the project `id` as a number, causing `json.Unmarshal` to fail with:

```
cannot unmarshal number into Go struct field DeployProject.id of type string
```

Added a custom `UnmarshalJSON` method on `DeployProject` that accepts both string and numeric `id` values, coercing numbers to strings.

