### PR TITLE
feat: Add ability to deploy versions

### DIFF
--- a/internal/clioptions/clioptions.go
+++ b/internal/clioptions/clioptions.go
@@ -166,7 +166,8 @@ func (o *CLIOptions) AddEnvironmentFlags(flags *pflag.FlagSet) {
 }
 
 func (o *CLIOptions) AddDeployFlags(flags *pflag.FlagSet) {
-	flags.StringVar(&o.Revision, "revision", "", "revision of the commit to deploy")
+	flags.StringVar(&o.Revision, "revision", "", "git revision of the commit to deploy")
+	flags.StringVar(&o.Version, "version", "", "version to deploy")
 	flags.StringVar(&o.DeployType, "deploy-type", "smart_deploy", "deploy type")
 	flags.BoolVar(&o.NoSemVer, "no-semver", false, "force the deploy wihout semver")
 }

--- a/internal/cmd/deploy/trigger.go
+++ b/internal/cmd/deploy/trigger.go
@@ -31,6 +31,9 @@ import (
 const (
 	deployProjectEndpointTemplate  = "/api/deploy/projects/%s/trigger/pipeline/"
 	pipelineStatusEndpointTemplate = "/api/deploy/projects/%s/pipelines/%s/status/"
+
+	pipelineStatusFailed = "failed"
+	refTypeRevision      = "revision"
 )
 
 func triggerCmd(options *clioptions.CLIOptions) *cobra.Command {
@@ -98,7 +101,7 @@ func runDeployTrigger(ctx context.Context, environmentName string, options *clio
 		return fmt.Errorf("error retrieving the pipeline status: %w", err)
 	}
 
-	if status == "failed" {
+	if status == pipelineStatusFailed {
 		return errors.New("pipeline failed")
 	}
 
@@ -107,7 +110,7 @@ func runDeployTrigger(ctx context.Context, environmentName string, options *clio
 }
 
 func triggerPipeline(ctx context.Context, client *client.APIClient, environmentName, projectID string, options *clioptions.CLIOptions) (*resources.DeployProject, error) {
-	refType := "revision"
+	refType := refTypeRevision
 	refValue := options.Revision
 	if len(options.Version) > 0 {
 		refType = "version"

--- a/internal/cmd/deploy/trigger.go
+++ b/internal/cmd/deploy/trigger.go
@@ -62,15 +62,14 @@ func deployTriggerOptions(cmd *cobra.Command, options *clioptions.CLIOptions) {
 	options.AddCompanyFlags(flags)
 	options.AddProjectFlags(flags)
 	options.AddDeployFlags(flags)
-	if err := cmd.MarkFlagRequired("revision"); err != nil {
-		// if there is an error something very wrong is happening, panic
-		panic(err)
-	}
 }
 
 func runDeployTrigger(ctx context.Context, environmentName string, options *clioptions.CLIOptions) error {
-	if len(options.Revision) == 0 {
-		return errors.New("a valid revision is required to start a deploy")
+	if len(options.Revision) == 0 && len(options.Version) == 0 {
+		return errors.New("one of --revision or --version is required to start a deploy")
+	}
+	if len(options.Revision) != 0 && len(options.Version) != 0 {
+		return errors.New("--revision and --version are mutually exclusive")
 	}
 
 	restConfig, err := options.ToRESTConfig()
@@ -108,9 +107,17 @@ func runDeployTrigger(ctx context.Context, environmentName string, options *clio
 }
 
 func triggerPipeline(ctx context.Context, client *client.APIClient, environmentName, projectID string, options *clioptions.CLIOptions) (*resources.DeployProject, error) {
+	refType := "revision"
+	refValue := options.Revision
+	if len(options.Version) > 0 {
+		refType = "version"
+		refValue = options.Version
+	}
+
 	request := resources.DeployProjectRequest{
 		Environment: environmentName,
-		Revision:    options.Revision,
+		Revision:    refValue,
+		RefType:     refType,
 		Type:        options.DeployType,
 		ForceDeploy: options.NoSemVer,
 	}

--- a/internal/cmd/deploy/trigger_test.go
+++ b/internal/cmd/deploy/trigger_test.go
@@ -35,30 +35,54 @@ func TestDeploy(t *testing.T) {
 	testCases := map[string]struct {
 		server    *httptest.Server
 		projectID string
+		revision  string
+		version   string
 		expectErr bool
 	}{
 		"pipeline succeed": {
 			server:    testTriggerServer(t),
 			projectID: "correct",
+			revision:  "revision",
+		},
+		"pipeline succeed with version": {
+			server:    testTriggerServer(t),
+			projectID: "correct",
+			version:   "1.0.0",
 		},
 		"pipeline failed": {
 			server:    testFailedTriggerServer(t),
 			projectID: "failed",
+			revision:  "revision",
 			expectErr: true,
 		},
 		"pipeline fails": {
 			server:    testTriggerServer(t),
 			projectID: "fails-bad-request",
+			revision:  "revision",
 			expectErr: true,
 		},
 		"wait status fails": {
 			server:    testTriggerServer(t),
 			projectID: "fails-wait-status",
+			revision:  "revision",
 			expectErr: true,
 		},
 		"missing project ID": {
 			server:    testTriggerServer(t),
 			projectID: "",
+			revision:  "revision",
+			expectErr: true,
+		},
+		"missing revision and version": {
+			server:    testTriggerServer(t),
+			projectID: "correct",
+			expectErr: true,
+		},
+		"revision and version are mutually exclusive": {
+			server:    testTriggerServer(t),
+			projectID: "correct",
+			revision:  "revision",
+			version:   "1.0.0",
 			expectErr: true,
 		},
 	}
@@ -70,7 +94,8 @@ func TestDeploy(t *testing.T) {
 			options := &clioptions.CLIOptions{
 				Endpoint:     server.URL,
 				ProjectID:    testCase.projectID,
-				Revision:     "revision",
+				Revision:     testCase.revision,
+				Version:      testCase.version,
 				MiactlConfig: filepath.Join(t.TempDir(), "nofile"),
 			}
 			err := runDeployTrigger(t.Context(), "environmentName", options)

--- a/internal/resources/requests.go
+++ b/internal/resources/requests.go
@@ -92,6 +92,7 @@ const (
 type DeployProjectRequest struct {
 	Environment string `json:"environment"`
 	Revision    string `json:"revision"`
+	RefType     string `json:"refType"`
 	Type        string `json:"deployType"`              //nolint: tagliatelle
 	ForceDeploy bool   `json:"forceDeployWhenNoSemver"` //nolint: tagliatelle
 }


### PR DESCRIPTION
## What this PR is for?
Currently, the deploy trigger command is unable to detect a version to deploy. Providing a version in `deploy trigger --revision {version} results in an error trying to locate the configuration.

## Changes
1. Add ability to deploy a version to a specified environment.