### PR TITLE
refactor: remove obsolete Console v14.0/v14.1 version checks from catalog and item-type-definition commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - support automatic OIDC endpoint discovery via OAuth2 Protected Resource Metadata ([RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)) when available, with fallback to the Mia-Platform browser login flow
 
+### Removed
+
+- obsolete Console version checks (v14.0.0/v14.1.0) from Catalog and Item Type Definition commands, superseded by the minimum required Console version v15.0.0
+
 ## [v0.24.0] - 2026-04-28
 
 ### Added

--- a/internal/cmd/catalog/apply/apply.go
+++ b/internal/cmd/catalog/apply/apply.go
@@ -32,13 +32,10 @@ import (
 	"github.com/mia-platform/miactl/internal/files"
 	"github.com/mia-platform/miactl/internal/resources/catalog"
 	"github.com/mia-platform/miactl/internal/resources/marketplace"
-	"github.com/mia-platform/miactl/internal/util"
 )
 
 const (
 	applyLong = `Create or update one or more Catalog items.
-
-This command works with Mia-Platform Console v14.0.0 or later.
 
 The flag -f accepts either files or directories. In case of directories, it explores them recursively.
 
@@ -82,14 +79,6 @@ func ApplyCmd(options *clioptions.CLIOptions) *cobra.Command {
 			cobra.CheckErr(err)
 			client, err := client.APIClientForConfig(restConfig)
 			cobra.CheckErr(err)
-
-			canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), client, 14, 0)
-			if versionError != nil {
-				return versionError
-			}
-			if !canUseNewAPI {
-				return catalog.ErrUnsupportedCompanyVersion
-			}
 
 			companyID := restConfig.CompanyID
 			if len(companyID) == 0 {

--- a/internal/cmd/catalog/apply/apply_test.go
+++ b/internal/cmd/catalog/apply/apply_test.go
@@ -24,7 +24,6 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,28 +31,10 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	"github.com/mia-platform/miactl/internal/client"
-	"github.com/mia-platform/miactl/internal/clioptions"
 	commonMarketplace "github.com/mia-platform/miactl/internal/cmd/common/marketplace"
 	"github.com/mia-platform/miactl/internal/resources/catalog"
 	"github.com/mia-platform/miactl/internal/resources/marketplace"
 )
-
-func TestApplyCommand(t *testing.T) {
-	t.Run("test post run - shows deprecated command message", func(t *testing.T) {
-		server := httptest.NewServer(unexecutedCmdMockServer(t))
-		defer server.Close()
-
-		opts := clioptions.NewCLIOptions()
-		opts.CompanyID = "company-id"
-		opts.Endpoint = server.URL
-
-		cmd := ApplyCmd(opts)
-		cmd.SetArgs([]string{"apply", "-f", "testdata/validItem1.json"})
-
-		err := cmd.Execute()
-		require.ErrorIs(t, err, catalog.ErrUnsupportedCompanyVersion)
-	})
-}
 
 func TestApplyBuildPathsFromDir(t *testing.T) {
 	t.Run("should read all files in dir retrieving paths", func(t *testing.T) {
@@ -1100,17 +1081,4 @@ func applyMockServer(t *testing.T, statusCode int, mockResponse interface{}) *ht
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		applyRequestHandler(t, w, r, statusCode, mockResponse)
 	}))
-}
-
-func unexecutedCmdMockServer(t *testing.T) http.HandlerFunc {
-	t.Helper()
-	return func(w http.ResponseWriter, r *http.Request) {
-		if strings.EqualFold(r.URL.Path, "/api/version") && r.Method == http.MethodGet {
-			_, err := w.Write([]byte(`{"major": "13", "minor":"6"}`))
-			require.NoError(t, err)
-		} else {
-			w.WriteHeader(http.StatusNotFound)
-			assert.Fail(t, "unexpected request: "+r.URL.Path)
-		}
-	}
 }

--- a/internal/cmd/catalog/delete.go
+++ b/internal/cmd/catalog/delete.go
@@ -25,9 +25,7 @@ import (
 	"github.com/mia-platform/miactl/internal/client"
 	"github.com/mia-platform/miactl/internal/clioptions"
 	commonMarketplace "github.com/mia-platform/miactl/internal/cmd/common/marketplace"
-	"github.com/mia-platform/miactl/internal/resources/catalog"
 	"github.com/mia-platform/miactl/internal/resources/marketplace"
-	"github.com/mia-platform/miactl/internal/util"
 )
 
 const (
@@ -35,8 +33,6 @@ const (
 	deleteItemByTupleEndpointTemplate = "/api/tenants/%s/marketplace/items/%s/versions/%s"
 
 	cmdDeleteLongDescription = `Delete a single Catalog item
-
-	This command works with Mia-Platform Console v14.0.0 or later.
 
 	You need to specify the companyId, itemId and version, via the respective flags (recommended). The company-id flag can be omitted if it is already set in the context.
 	`
@@ -55,14 +51,6 @@ func DeleteCmd(options *clioptions.CLIOptions) *cobra.Command {
 			cobra.CheckErr(err)
 			client, err := client.APIClientForConfig(restConfig)
 			cobra.CheckErr(err)
-
-			canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), client, 14, 0)
-			if versionError != nil {
-				return versionError
-			}
-			if !canUseNewAPI {
-				return catalog.ErrUnsupportedCompanyVersion
-			}
 
 			companyID := restConfig.CompanyID
 			if len(companyID) == 0 {

--- a/internal/cmd/catalog/delete_test.go
+++ b/internal/cmd/catalog/delete_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/mia-platform/miactl/internal/client"
 	"github.com/mia-platform/miactl/internal/clioptions"
 	commonMarketplace "github.com/mia-platform/miactl/internal/cmd/common/marketplace"
-	"github.com/mia-platform/miactl/internal/resources/catalog"
 	"github.com/mia-platform/miactl/internal/resources/marketplace"
 )
 
@@ -40,21 +39,6 @@ func TestDeleteResourceCmd(t *testing.T) {
 		opts := clioptions.NewCLIOptions()
 		cmd := DeleteCmd(opts)
 		require.NotNil(t, cmd)
-	})
-
-	t.Run("should not run command when Console version is lower than 14.0.0", func(t *testing.T) {
-		server := httptest.NewServer(unexecutedCmdMockServer(t))
-		defer server.Close()
-
-		opts := clioptions.NewCLIOptions()
-		opts.CompanyID = mockDeleteCompanyID
-		opts.Endpoint = server.URL
-
-		cmd := DeleteCmd(opts)
-		cmd.SetArgs([]string{"delete", "--item-id", "some-item-id", "--version", "1.0.0"})
-
-		err := cmd.Execute()
-		require.ErrorIs(t, err, catalog.ErrUnsupportedCompanyVersion)
 	})
 }
 

--- a/internal/cmd/catalog/get.go
+++ b/internal/cmd/catalog/get.go
@@ -25,17 +25,13 @@ import (
 	"github.com/mia-platform/miactl/internal/clioptions"
 	commonMarketplace "github.com/mia-platform/miactl/internal/cmd/common/marketplace"
 	"github.com/mia-platform/miactl/internal/encoding"
-	"github.com/mia-platform/miactl/internal/resources/catalog"
 	"github.com/mia-platform/miactl/internal/resources/marketplace"
-	"github.com/mia-platform/miactl/internal/util"
 )
 
 const (
 	getItemByItemIDAndVersionEndpointTemplate = "/api/tenants/%s/marketplace/items/%s/versions/%s"
 
 	cmdGetLongDescription = `Get a single Catalog item
-
-	This command works with Mia-Platform Console v14.0.0 or later.
 
 	You need to specify the itemId, via the respective flag. The company-id flag can be omitted if it is already set in the context.
 	`
@@ -53,14 +49,6 @@ func GetCmd(options *clioptions.CLIOptions) *cobra.Command {
 			cobra.CheckErr(err)
 			client, err := client.APIClientForConfig(restConfig)
 			cobra.CheckErr(err)
-
-			canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), client, 14, 0)
-			if versionError != nil {
-				return versionError
-			}
-			if !canUseNewAPI {
-				return catalog.ErrUnsupportedCompanyVersion
-			}
 
 			serializedItem, err := getItemEncodedWithFormat(
 				cmd.Context(),

--- a/internal/cmd/catalog/get_test.go
+++ b/internal/cmd/catalog/get_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/mia-platform/miactl/internal/client"
 	"github.com/mia-platform/miactl/internal/clioptions"
 	"github.com/mia-platform/miactl/internal/encoding"
-	"github.com/mia-platform/miactl/internal/resources/catalog"
 )
 
 const (
@@ -83,21 +82,6 @@ func TestGetResourceCmd(t *testing.T) {
 		opts := clioptions.NewCLIOptions()
 		cmd := GetCmd(opts)
 		require.NotNil(t, cmd)
-	})
-
-	t.Run("should not run command when Console version is lower than 14.0.0", func(t *testing.T) {
-		server := httptest.NewServer(unexecutedCmdMockServer(t))
-		defer server.Close()
-
-		opts := clioptions.NewCLIOptions()
-		opts.CompanyID = mockCompanyID
-		opts.Endpoint = server.URL
-
-		cmd := GetCmd(opts)
-		cmd.SetArgs([]string{"get", "--item-id", mockItemID, "--version", mockVersion})
-
-		err := cmd.Execute()
-		require.ErrorIs(t, err, catalog.ErrUnsupportedCompanyVersion)
 	})
 }
 

--- a/internal/cmd/catalog/list.go
+++ b/internal/cmd/catalog/list.go
@@ -21,15 +21,13 @@ import (
 	"github.com/mia-platform/miactl/internal/client"
 	"github.com/mia-platform/miactl/internal/clioptions"
 	commonMarketplace "github.com/mia-platform/miactl/internal/cmd/common/marketplace"
-	"github.com/mia-platform/miactl/internal/resources/catalog"
-	"github.com/mia-platform/miactl/internal/util"
 )
 
 const (
 	listMarketplaceEndpoint = "/api/marketplace/"
 	listCmdLong             = `List Catalog items
 
-    This command lists the Catalog items of a company. It works with Mia-Platform Console v14.0.0 or later.
+    This command lists the Catalog items of a company.
 
 		Results are paginated. By default, only the first page is shown.
 
@@ -61,14 +59,6 @@ func runListCmd(options *clioptions.CLIOptions) func(cmd *cobra.Command, args []
 		cobra.CheckErr(err)
 		apiClient, err := client.APIClientForConfig(restConfig)
 		cobra.CheckErr(err)
-
-		canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), apiClient, 14, 0)
-		if versionError != nil {
-			return versionError
-		}
-		if !canUseNewAPI {
-			return catalog.ErrUnsupportedCompanyVersion
-		}
 
 		marketplaceItemsOptions := commonMarketplace.GetMarketplaceItemsOptions{
 			CompanyID: restConfig.CompanyID,

--- a/internal/cmd/catalog/list_test.go
+++ b/internal/cmd/catalog/list_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/mia-platform/miactl/internal/clioptions"
 	commonMarketplace "github.com/mia-platform/miactl/internal/cmd/common/marketplace"
 	"github.com/mia-platform/miactl/internal/printer"
-	"github.com/mia-platform/miactl/internal/resources/catalog"
 )
 
 func TestNewGetCmd(t *testing.T) {
@@ -36,21 +35,6 @@ func TestNewGetCmd(t *testing.T) {
 		opts := clioptions.NewCLIOptions()
 		cmd := ListCmd(opts)
 		require.NotNil(t, cmd)
-	})
-
-	t.Run("should not run command when Console version is lower than 14.0.0", func(t *testing.T) {
-		server := httptest.NewServer(unexecutedCmdMockServer(t))
-		defer server.Close()
-
-		opts := clioptions.NewCLIOptions()
-		opts.CompanyID = "my-company"
-		opts.Endpoint = server.URL
-
-		cmd := ListCmd(opts)
-		cmd.SetArgs([]string{"list"})
-
-		err := cmd.Execute()
-		require.ErrorIs(t, err, catalog.ErrUnsupportedCompanyVersion)
 	})
 }
 
@@ -136,19 +120,6 @@ func TestBuildMarketplaceItemsList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			runTestCase(t, tc)
 		})
-	}
-}
-
-func unexecutedCmdMockServer(t *testing.T) http.HandlerFunc {
-	t.Helper()
-	return func(w http.ResponseWriter, r *http.Request) {
-		if strings.EqualFold(r.URL.Path, "/api/version") && r.Method == http.MethodGet {
-			_, err := w.Write([]byte(`{"major": "13", "minor":"6"}`))
-			require.NoError(t, err)
-		} else {
-			w.WriteHeader(http.StatusNotFound)
-			assert.Fail(t, "unexpected request: "+r.URL.Path)
-		}
 	}
 }
 

--- a/internal/cmd/catalog/list_versions.go
+++ b/internal/cmd/catalog/list_versions.go
@@ -21,8 +21,6 @@ import (
 	"github.com/mia-platform/miactl/internal/client"
 	"github.com/mia-platform/miactl/internal/clioptions"
 	commonMarketplace "github.com/mia-platform/miactl/internal/cmd/common/marketplace"
-	"github.com/mia-platform/miactl/internal/resources/catalog"
-	"github.com/mia-platform/miactl/internal/util"
 )
 
 const listItemVersionsEndpointTemplate = "/api/tenants/%s/marketplace/items/%s/versions"
@@ -33,20 +31,12 @@ func ListVersionCmd(options *clioptions.CLIOptions) *cobra.Command {
 		Use:   "list-versions",
 		Short: "List versions of a Marketplace item",
 		Long: `List the currently available versions of a Marketplace item.
-The command will output a table with each version of the item. It works with Mia-Platform Console v14.0.0 or later.`,
+The command will output a table with each version of the item.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			restConfig, err := options.ToRESTConfig()
 			cobra.CheckErr(err)
 			client, err := client.APIClientForConfig(restConfig)
 			cobra.CheckErr(err)
-
-			canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), client, 14, 0)
-			if versionError != nil {
-				return versionError
-			}
-			if !canUseNewAPI {
-				return catalog.ErrUnsupportedCompanyVersion
-			}
 
 			releases, err := commonMarketplace.GetItemVersions(
 				cmd.Context(),

--- a/internal/cmd/catalog/list_versions_test.go
+++ b/internal/cmd/catalog/list_versions_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/mia-platform/miactl/internal/clioptions"
 	commonMarketplace "github.com/mia-platform/miactl/internal/cmd/common/marketplace"
 	"github.com/mia-platform/miactl/internal/printer"
-	"github.com/mia-platform/miactl/internal/resources/catalog"
 	"github.com/mia-platform/miactl/internal/resources/marketplace"
 )
 
@@ -66,21 +65,6 @@ func TestNewListVersionsCmd(t *testing.T) {
 		opts := clioptions.NewCLIOptions()
 		cmd := ListVersionCmd(opts)
 		require.NotNil(t, cmd)
-	})
-
-	t.Run("should not run command when Console version is lower than 14.0.0", func(t *testing.T) {
-		server := httptest.NewServer(unexecutedCmdMockServer(t))
-		defer server.Close()
-
-		opts := clioptions.NewCLIOptions()
-		opts.CompanyID = "my-company"
-		opts.Endpoint = server.URL
-
-		cmd := ListVersionCmd(opts)
-		cmd.SetArgs([]string{"list-versions", "--item-id", "item-id"})
-
-		err := cmd.Execute()
-		require.ErrorIs(t, err, catalog.ErrUnsupportedCompanyVersion)
 	})
 }
 

--- a/internal/cmd/item-type-definition/delete.go
+++ b/internal/cmd/item-type-definition/delete.go
@@ -26,7 +26,6 @@ import (
 	"github.com/mia-platform/miactl/internal/client"
 	"github.com/mia-platform/miactl/internal/clioptions"
 	itd "github.com/mia-platform/miactl/internal/resources/item-type-definition"
-	"github.com/mia-platform/miactl/internal/util"
 )
 
 var (
@@ -37,7 +36,7 @@ var (
 const (
 	deleteItdEndpoint = "/api/tenants/%s/marketplace/item-type-definitions/%s/"
 
-	cmdDeleteLongDescription = `Delete an Item Type Definition. It works with Mia-Platform Console v14.1.0 or later.
+	cmdDeleteLongDescription = `Delete an Item Type Definition.
 
 	You need to specify the companyId and the item type definition name via the respective flags (recommended). The company-id flag can be omitted if it is already set in the context.
 	`
@@ -55,14 +54,6 @@ func DeleteCmd(options *clioptions.CLIOptions) *cobra.Command {
 			cobra.CheckErr(err)
 			client, err := client.APIClientForConfig(restConfig)
 			cobra.CheckErr(err)
-
-			canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), client, 14, 1)
-			if versionError != nil {
-				return versionError
-			}
-			if !canUseNewAPI {
-				return itd.ErrUnsupportedCompanyVersion
-			}
 
 			companyID := restConfig.CompanyID
 			if len(companyID) == 0 {

--- a/internal/cmd/item-type-definition/delete_test.go
+++ b/internal/cmd/item-type-definition/delete_test.go
@@ -39,21 +39,6 @@ func TestDeleteResourceCmd(t *testing.T) {
 		cmd := DeleteCmd(opts)
 		require.NotNil(t, cmd)
 	})
-
-	t.Run("should not run command when Console version is lower than 14.1.0", func(t *testing.T) {
-		server := httptest.NewServer(unexecutedCmdMockServer(t))
-		defer server.Close()
-
-		opts := clioptions.NewCLIOptions()
-		opts.CompanyID = mockDeleteCompanyID
-		opts.Endpoint = server.URL
-
-		cmd := DeleteCmd(opts)
-		cmd.SetArgs([]string{"delete", "--name", "some-item-id"})
-
-		err := cmd.Execute()
-		require.ErrorIs(t, err, itd.ErrUnsupportedCompanyVersion)
-	})
 }
 
 func deleteByItemNameMockServer(t *testing.T,

--- a/internal/cmd/item-type-definition/get.go
+++ b/internal/cmd/item-type-definition/get.go
@@ -25,14 +25,13 @@ import (
 	"github.com/mia-platform/miactl/internal/client"
 	"github.com/mia-platform/miactl/internal/clioptions"
 	itd "github.com/mia-platform/miactl/internal/resources/item-type-definition"
-	"github.com/mia-platform/miactl/internal/util"
 )
 
 const (
 	getItdEndpoint = "/api/tenants/%s/marketplace/item-type-definitions/%s/"
 	getCmdLong     = `Get an Item Type Definition
 
-   This command get an Item Type Definitions based on its name and tenant namespace. It works with Mia-Platform Console v14.1.0 or later.
+   This command get an Item Type Definitions based on its name and tenant namespace.
 
    You need to specify the name via the respective flag. The company-id flag can be omitted if it is already set in the context and it is used as tenantId of the item type definition.
    `
@@ -49,14 +48,6 @@ func GetCmd(options *clioptions.CLIOptions) *cobra.Command {
 			cobra.CheckErr(err)
 			client, err := client.APIClientForConfig(restConfig)
 			cobra.CheckErr(err)
-
-			canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), client, 14, 1)
-			if versionError != nil {
-				return versionError
-			}
-			if !canUseNewAPI {
-				return itd.ErrUnsupportedCompanyVersion
-			}
 
 			serializedItem, err := getItemEncodedWithFormat(
 				cmd.Context(),

--- a/internal/cmd/item-type-definition/get_test.go
+++ b/internal/cmd/item-type-definition/get_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/mia-platform/miactl/internal/client"
 	"github.com/mia-platform/miactl/internal/clioptions"
 	"github.com/mia-platform/miactl/internal/encoding"
-	itd "github.com/mia-platform/miactl/internal/resources/item-type-definition"
 )
 
 const (
@@ -79,21 +78,6 @@ func TestGetResourceCmd(t *testing.T) {
 		opts := clioptions.NewCLIOptions()
 		cmd := GetCmd(opts)
 		require.NotNil(t, cmd)
-	})
-
-	t.Run("should not run command when Console version is lower than 14.1.0", func(t *testing.T) {
-		server := httptest.NewServer(unexecutedCmdMockServer(t))
-		defer server.Close()
-
-		opts := clioptions.NewCLIOptions()
-		opts.CompanyID = mockCompanyID
-		opts.Endpoint = server.URL
-
-		cmd := GetCmd(opts)
-		cmd.SetArgs([]string{"get", "--name", mockName})
-
-		err := cmd.Execute()
-		require.ErrorIs(t, err, itd.ErrUnsupportedCompanyVersion)
 	})
 }
 

--- a/internal/cmd/item-type-definition/list.go
+++ b/internal/cmd/item-type-definition/list.go
@@ -26,7 +26,6 @@ import (
 	"github.com/mia-platform/miactl/internal/clioptions"
 	"github.com/mia-platform/miactl/internal/printer"
 	itd "github.com/mia-platform/miactl/internal/resources/item-type-definition"
-	"github.com/mia-platform/miactl/internal/util"
 )
 
 type GetItdsOptions struct {
@@ -39,7 +38,7 @@ const (
 	listItdEndpoint = "/api/marketplace/item-type-definitions/"
 	listCmdLong     = `List Item Type Definitions
 
-    This command lists the Item Type Definitions of a company. It works with Mia-Platform Console v14.1.0 or later.
+    This command lists the Item Type Definitions of a company.
 
 		Results are paginated. By default, only the first page is shown.
 
@@ -70,14 +69,6 @@ func runListCmd(options *clioptions.CLIOptions) func(cmd *cobra.Command, args []
 		cobra.CheckErr(err)
 		apiClient, err := client.APIClientForConfig(restConfig)
 		cobra.CheckErr(err)
-
-		canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), apiClient, 14, 1)
-		if versionError != nil {
-			return versionError
-		}
-		if !canUseNewAPI {
-			return itd.ErrUnsupportedCompanyVersion
-		}
 
 		listItemsOptions := GetItdsOptions{
 			CompanyID: restConfig.CompanyID,

--- a/internal/cmd/item-type-definition/list_test.go
+++ b/internal/cmd/item-type-definition/list_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/mia-platform/miactl/internal/client"
 	"github.com/mia-platform/miactl/internal/clioptions"
 	"github.com/mia-platform/miactl/internal/printer"
-	itd "github.com/mia-platform/miactl/internal/resources/item-type-definition"
 )
 
 func TestGetCmd(t *testing.T) {
@@ -36,21 +35,6 @@ func TestGetCmd(t *testing.T) {
 		opts := clioptions.NewCLIOptions()
 		cmd := ListCmd(opts)
 		require.NotNil(t, cmd)
-	})
-
-	t.Run("should not run command when Console version is lower than 14.1.0", func(t *testing.T) {
-		server := httptest.NewServer(unexecutedCmdMockServer(t))
-		defer server.Close()
-
-		opts := clioptions.NewCLIOptions()
-		opts.CompanyID = "my-company"
-		opts.Endpoint = server.URL
-
-		cmd := ListCmd(opts)
-		cmd.SetArgs([]string{"list"})
-
-		err := cmd.Execute()
-		require.ErrorIs(t, err, itd.ErrUnsupportedCompanyVersion)
 	})
 }
 
@@ -127,18 +111,6 @@ func TestBuildMarketplaceItemsList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			runTestCase(t, tc)
 		})
-	}
-}
-
-func unexecutedCmdMockServer(t *testing.T) http.HandlerFunc {
-	t.Helper()
-	return func(w http.ResponseWriter, r *http.Request) {
-		if strings.EqualFold(r.URL.Path, "/api/version") && r.Method == http.MethodGet {
-			fmt.Fprint(w, `{"major": "14", "minor":"0"}`)
-		} else {
-			w.WriteHeader(http.StatusNotFound)
-			assert.Fail(t, "unexpected request: "+r.URL.Path)
-		}
 	}
 }
 

--- a/internal/cmd/item-type-definition/put.go
+++ b/internal/cmd/item-type-definition/put.go
@@ -30,7 +30,6 @@ import (
 	"github.com/mia-platform/miactl/internal/encoding"
 	"github.com/mia-platform/miactl/internal/files"
 	itd "github.com/mia-platform/miactl/internal/resources/item-type-definition"
-	"github.com/mia-platform/miactl/internal/util"
 )
 
 var (
@@ -45,7 +44,7 @@ var (
 const (
 	putItdEndpoint = "/api/tenants/%s/marketplace/item-type-definitions/"
 
-	cmdPutLongDescription = ` Create or update an Item Type Definition. It works with Mia-Platform Console v14.1.0 or later.
+	cmdPutLongDescription = ` Create or update an Item Type Definition.
 
   You need to specify the flag --file or -f that accepts a file and companyId.
 
@@ -72,14 +71,6 @@ func PutCmd(options *clioptions.CLIOptions) *cobra.Command {
 			cobra.CheckErr(err)
 			client, err := client.APIClientForConfig(restConfig)
 			cobra.CheckErr(err)
-
-			canUseNewAPI, versionError := util.VersionCheck(cmd.Context(), client, 14, 1)
-			if versionError != nil {
-				return versionError
-			}
-			if !canUseNewAPI {
-				return itd.ErrUnsupportedCompanyVersion
-			}
 
 			companyID := restConfig.CompanyID
 			if len(companyID) == 0 {

--- a/internal/cmd/item-type-definition/put_test.go
+++ b/internal/cmd/item-type-definition/put_test.go
@@ -24,26 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mia-platform/miactl/internal/client"
-	"github.com/mia-platform/miactl/internal/clioptions"
 	itd "github.com/mia-platform/miactl/internal/resources/item-type-definition"
 )
-
-func TestPutCommand(t *testing.T) {
-	t.Run("test post run - shows deprecated command message", func(t *testing.T) {
-		server := httptest.NewServer(unexecutedCmdMockServer(t))
-		defer server.Close()
-
-		opts := clioptions.NewCLIOptions()
-		opts.CompanyID = "company-id"
-		opts.Endpoint = server.URL
-
-		cmd := PutCmd(opts)
-		cmd.SetArgs([]string{"put", "--file", "testdata/validItem1.json"})
-
-		err := cmd.Execute()
-		require.ErrorIs(t, err, itd.ErrUnsupportedCompanyVersion)
-	})
-}
 
 var mockTenantID = "mock-tenant-id"
 var mockURI = "/api/tenants/" + mockTenantID + "/marketplace/item-type-definitions/"

--- a/internal/resources/catalog/catalog.go
+++ b/internal/resources/catalog/catalog.go
@@ -16,13 +16,7 @@
 package catalog
 
 import (
-	"errors"
-
 	"github.com/mia-platform/miactl/internal/resources/marketplace"
-)
-
-var (
-	ErrUnsupportedCompanyVersion = errors.New("you need Mia-Platform Console v14.0.0 or later to use this command")
 )
 
 type ApplyResponse struct {

--- a/internal/resources/item-type-definition/item-type-definition.go
+++ b/internal/resources/item-type-definition/item-type-definition.go
@@ -22,9 +22,8 @@ import (
 )
 
 var (
-	ErrUnsupportedCompanyVersion = errors.New("you need Mia-Platform Console v14.1.0 or later to use this command")
-	ErrMissingCompanyID          = errors.New("missing company id, please set one with the flag company-id or in the context")
-	ErrItemNotFound              = errors.New("item type definition not found")
+	ErrMissingCompanyID = errors.New("missing company id, please set one with the flag company-id or in the context")
+	ErrItemNotFound     = errors.New("item type definition not found")
 )
 
 // GenericItemTypeDefinition is a Marketplace item


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
of the work you have done and be sure to link to the relative open issue if is present.

Be aware that all the work you have done should include also the relative tests to assure the
correct behavior and avoid possible regressions in the future.
-->

## What this PR is for?

Remove API request to `/api/version` to verify whether `item-type-definition` and `catalog` commands work (meaning: Mia-Platform Console v14.1 or above). Considering that the latest miactl version works with Mia-Platform Console v15 and above, these check are not necessary anymore.
<!--
Describe what this PR is trying to achieve, for example is this a PR that fix an open issue? Is for a new feature? etc.
-->
